### PR TITLE
Update README and ENV parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We provide docker images for the agent itself. The only other dependency is a Po
 
 We provide a docker-compose file to start the agent and the Postgres database.
 
-Edit the `.env.production` file in the root of the project. You need to set the `PUBLIC_URL` and the API key for at least OpenAI.
+Edit the `.env.production` file in the root of the project. You need to set the `PUBLIC_URL`, `DATABASE_URL`, and the API key for at least OpenAI.
 
 Start a local instance via docker compose:
 

--- a/apps/dbagent/.env.production
+++ b/apps/dbagent/.env.production
@@ -1,0 +1,10 @@
+# Public URL of the app
+PUBLIC_URL=http://localhost:8080
+
+# LLM API credentials
+OPENAI_API_KEY=
+DEEPSEEK_API_KEY=
+ANTHROPIC_API_KEY=
+
+# The URL of the database that we use to store data
+DATABASE_URL='postgres://...'


### PR DESCRIPTION
Fixes #57

Add `DATABASE_URL` field to `.env.production` and update README to reflect the need for a Postgres database.

* **.env.production**: Add `DATABASE_URL` field to the file.
* **README.md**: Update instructions to include setting the `DATABASE_URL` field in `.env.production`.