### PR TITLE
Split tools

### DIFF
--- a/apps/dbagent/src/lib/ai/aidba.ts
+++ b/apps/dbagent/src/lib/ai/aidba.ts
@@ -2,25 +2,8 @@ import { anthropic } from '@ai-sdk/anthropic';
 import { deepseek } from '@ai-sdk/deepseek';
 import { openai } from '@ai-sdk/openai';
 import { LanguageModelV1, Tool } from 'ai';
-import { z } from 'zod';
-import {
-  getPerformanceAndVacuumSettings,
-  getPostgresExtensions,
-  getTablesAndInstanceInfo,
-  toolFindTableSchema
-} from '~/lib/tools/dbinfo';
-import { getInstanceLogs } from '~/lib/tools/logs';
-import { getClusterMetric } from '~/lib/tools/metrics';
-import { getPlaybook, listPlaybooks } from '~/lib/tools/playbooks';
-import { toolDescribeTable, toolExplainQuery, toolGetSlowQueries } from '~/lib/tools/slow-queries';
-import { Connection } from '../db/connections';
-import {
-  toolCurrentActiveQueries,
-  toolGetConnectionsGroups,
-  toolGetConnectionsStats,
-  toolGetQueriesWaitingOnLocks,
-  toolGetVacuumStats
-} from '../tools/stats';
+import { Connection } from '~/lib/db/connections';
+import { commonToolset, getDBClusterTools, getDBSQLTools, mergeToolsets, playbookToolset } from './tools';
 
 export const commonSystemPrompt = `
 You are an AI assistant expert in PostgreSQL and database administration.
@@ -33,8 +16,8 @@ export const chatSystemPrompt = `${commonSystemPrompt}
 Provide clear, concise, and accurate responses to questions.
 Use the provided tools to get context from the PostgreSQL database to answer questions.
 When asked why a query is slow, call the explainQuery tool and also take into account the table sizes.
-During the initial assessment use the getTablesAndInstanceInfo, getPerfromanceAndVacuumSettings, 
-and getPostgresExtensions tools. 
+During the initial assessment use the getTablesAndInstanceInfo, getPerfromanceAndVacuumSettings,
+and getPostgresExtensions tools.
 When asked to run a playbook, use the getPlaybook tool to get the playbook contents. Then use the contents of the playbook
 as an action plan. Execute the plan step by step.
 `;
@@ -48,166 +31,9 @@ At the end of your execution, print a summary of the results.
 `;
 
 export async function getTools(connection: Connection, asUserId?: string): Promise<Record<string, Tool>> {
-  return {
-    getCurrentTime: {
-      description: 'Get the current time',
-      parameters: z.object({}),
-      execute: async () => {
-        const now = new Date();
-        return now.toLocaleTimeString();
-      }
-    },
-    getSlowQueries: {
-      description: `Get a list of slow queries formatted as a JSON array. Contains how many times the query was called,
-the max execution time in seconds, the mean execution time in seconds, the total execution time
-(all calls together) in seconds, and the query itself.`,
-      parameters: z.object({}),
-      execute: async () => {
-        console.log('getSlowQueries');
-        const slowQueries = await toolGetSlowQueries(connection.connectionString, 2000);
-        console.log('slowQueries', JSON.stringify(slowQueries));
-        return JSON.stringify(slowQueries);
-      }
-    },
-    explainQuery: {
-      description: `Run explain on a a query. Returns the explain plan as received from PostgreSQL. 
-The query needs to be complete, it cannot contain $1, $2, etc. If you need to, replace the parameters with your own made up values.
-It's very important that $1, $2, etc. are not passed to this tool. Use the tool describeTable to get the types of the columns.
-If you know the schema, pass it in as well.`,
-      parameters: z.object({
-        schema: z.string(),
-        query: z.string()
-      }),
-      execute: async ({ schema, query }) => {
-        if (!schema) {
-          schema = 'public';
-        }
-        const explain = await toolExplainQuery(connection.connectionString, schema, query);
-        if (explain) {
-          return explain;
-        } else {
-          return 'Could not run EXPLAIN on the query';
-        }
-      }
-    },
-    describeTable: {
-      description: `Describe a table. If you know the schema, pass it as a parameter. If you don't, use public.`,
-      parameters: z.object({
-        schema: z.string(),
-        table: z.string()
-      }),
-      execute: async ({ schema, table }) => {
-        if (!schema) {
-          schema = 'public';
-        }
-        return await toolDescribeTable(connection.connectionString, schema, table);
-      }
-    },
-    findTableSchema: {
-      description: `Find the schema of a table. Use this tool to find the schema of a table.`,
-      parameters: z.object({
-        table: z.string()
-      }),
-      execute: async ({ table }) => {
-        return await toolFindTableSchema(connection.connectionString, table);
-      }
-    },
-    getTablesAndInstanceInfo: {
-      description: `Get the information about tables (sizes, row counts, usage) and the data about server
-instance/cluster on which the DB is running. Useful during the initial assessment.`,
-      parameters: z.object({}),
-      execute: async () => {
-        return await getTablesAndInstanceInfo(connection, asUserId);
-      }
-    },
-    getPerformanceAndVacuumSettings: {
-      description: `Get the performance and vacuum settings for the database.`,
-      parameters: z.object({}),
-      execute: async () => {
-        return await getPerformanceAndVacuumSettings(connection);
-      }
-    },
-    getPostgresExtensions: {
-      description: `Get the available and installed PostgreSQL extensions for the database.`,
-      parameters: z.object({}),
-      execute: async () => {
-        return await getPostgresExtensions(connection, asUserId);
-      }
-    },
-    getInstanceLogs: {
-      description: `Get the recent logs from the RDS instance. You can specify the period in seconds and optionally grep for a substring.`,
-      parameters: z.object({
-        periodInSeconds: z.number(),
-        grep: z.string().optional()
-      }),
-      execute: async ({ periodInSeconds, grep }) => {
-        console.log('getInstanceLogs', periodInSeconds, grep);
-        return await getInstanceLogs({ connection, periodInSeconds, grep, asUserId });
-      }
-    },
-    getInstanceMetric: {
-      description: `Get the metrics for the RDS instance. You can specify the period in seconds.`,
-      parameters: z.object({
-        metricName: z.string(),
-        periodInSeconds: z.number()
-      }),
-      execute: async ({ metricName, periodInSeconds }) => {
-        console.log('getClusterMetric', metricName, periodInSeconds);
-        return await getClusterMetric({ connection, metricName, periodInSeconds, asUserId });
-      }
-    },
-    getCurrentActiveQueries: {
-      description: `Get the currently active queries.`,
-      parameters: z.object({}),
-      execute: async () => {
-        return await toolCurrentActiveQueries(connection.connectionString);
-      }
-    },
-    getQueriesWaitingOnLocks: {
-      description: `Get the queries that are currently blocked waiting on locks.`,
-      parameters: z.object({}),
-      execute: async () => {
-        return await toolGetQueriesWaitingOnLocks(connection.connectionString);
-      }
-    },
-    getVacuumStats: {
-      description: `Get the vacuum stats for the top tables in the database. They are sorted by the number of dead tuples descending.`,
-      parameters: z.object({}),
-      execute: async () => {
-        return await toolGetVacuumStats(connection.connectionString);
-      }
-    },
-    getConnectionsStats: {
-      description: `Get the connections stats for the database.`,
-      parameters: z.object({}),
-      execute: async () => {
-        return await toolGetConnectionsStats(connection.connectionString);
-      }
-    },
-    getConnectionsGroups: {
-      description: `Get the connections groups for the database. This is a view in the pg_stat_activity table, grouped by (state, user, application_name, client_addr, wait_event_type, wait_event).`,
-      parameters: z.object({}),
-      execute: async () => {
-        return await toolGetConnectionsGroups(connection.connectionString);
-      }
-    },
-    getPlaybook: {
-      description: `Get a playbook contents by name. A playbook is a list of steps to follow to achieve a goal. Follow it step by step.`,
-      parameters: z.object({
-        name: z.string()
-      }),
-      execute: async ({ name }) => {
-        return getPlaybook(name);
-      }
-    },
-    listPlaybooks: {
-      description: `List the available playbooks.`,
-      parameters: z.object({}),
-      execute: async () => {
-        return listPlaybooks();
-      }
-    }
-  };
+  const dbTools = getDBSQLTools(connection.connectionString);
+  const clusterTools = getDBClusterTools(connection, asUserId);
+  return mergeToolsets(commonToolset, playbookToolset, dbTools, clusterTools);
 }
 
 export function getModelInstance(model: string): LanguageModelV1 {

--- a/apps/dbagent/src/lib/ai/tools/cluster.ts
+++ b/apps/dbagent/src/lib/ai/tools/cluster.ts
@@ -1,0 +1,86 @@
+import { tool, Tool } from 'ai';
+import { z } from 'zod';
+import { Connection } from '~/lib/db/connections';
+import { getPostgresExtensions, getTablesAndInstanceInfo } from '~/lib/tools/dbinfo';
+import { getInstanceLogs } from '~/lib/tools/logs';
+import { getClusterMetric } from '~/lib/tools/metrics';
+import { ToolsetGroup } from './types';
+
+export function getDBClusterTools(connection: Connection, asUserId?: string): Record<string, Tool> {
+  return new DBClusterTools(() => Promise.resolve({ connection, asUserId })).toolset();
+}
+
+// The DBClusterTools toolset provides agent tools for accessing information about AWS RDS instance and cluster.
+export class DBClusterTools implements ToolsetGroup {
+  private _connection: () => Promise<{ connection: Connection; asUserId?: string }>;
+
+  constructor(getter: () => Promise<{ connection: Connection; asUserId?: string }>) {
+    this._connection = getter;
+  }
+
+  toolset(): Record<string, Tool> {
+    return {
+      getTablesAndInstanceInfo: this.getTablesAndInstanceInfo(),
+      getPostgresExtensions: this.getPostgresExtensions(),
+      getInstanceLogs: this.getInstanceLogs(),
+      getInstanceMetric: this.getInstanceMetric()
+    };
+  }
+
+  private getTablesAndInstanceInfo(): Tool {
+    const getter = this._connection;
+    return tool({
+      description: `Get the information about tables (sizes, row counts, usage) and the data about server
+instance/cluster on which the DB is running. Useful during the initial assessment.`,
+      parameters: z.object({}),
+      execute: async () => {
+        const { connection, asUserId } = await getter();
+        return await getTablesAndInstanceInfo(connection, asUserId);
+      }
+    });
+  }
+
+  private getPostgresExtensions(): Tool {
+    const getter = this._connection;
+    return tool({
+      description: `Get the available and installed PostgreSQL extensions for the database.`,
+      parameters: z.object({}),
+      execute: async () => {
+        const { connection, asUserId } = await getter();
+        return await getPostgresExtensions(connection, asUserId);
+      }
+    });
+  }
+
+  private getInstanceLogs(): Tool {
+    const getter = this._connection;
+    return tool({
+      description: `Get the recent logs from the RDS instance. You can specify the period in seconds and optionally grep for a substring.`,
+      parameters: z.object({
+        periodInSeconds: z.number(),
+        grep: z.string().optional()
+      }),
+      execute: async ({ periodInSeconds, grep }) => {
+        console.log('getInstanceLogs', periodInSeconds, grep);
+        const { connection, asUserId } = await getter();
+        return await getInstanceLogs({ connection, periodInSeconds, grep, asUserId });
+      }
+    });
+  }
+
+  private getInstanceMetric(): Tool {
+    const getter = this._connection;
+    return tool({
+      description: `Get the metrics for the RDS instance. You can specify the period in seconds.`,
+      parameters: z.object({
+        metricName: z.string(),
+        periodInSeconds: z.number()
+      }),
+      execute: async ({ metricName, periodInSeconds }) => {
+        console.log('getClusterMetric', metricName, periodInSeconds);
+        const { connection, asUserId } = await getter();
+        return await getClusterMetric({ connection, metricName, periodInSeconds, asUserId });
+      }
+    });
+  }
+}

--- a/apps/dbagent/src/lib/ai/tools/common.ts
+++ b/apps/dbagent/src/lib/ai/tools/common.ts
@@ -1,0 +1,15 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+export const getCurrentTime = tool({
+  description: 'Get the current time',
+  parameters: z.object({}),
+  execute: async () => {
+    const now = new Date();
+    return now.toLocaleTimeString();
+  }
+});
+
+export const commonToolset = {
+  getCurrentTime
+};

--- a/apps/dbagent/src/lib/ai/tools/db.ts
+++ b/apps/dbagent/src/lib/ai/tools/db.ts
@@ -1,0 +1,178 @@
+import { Tool, tool } from 'ai';
+import { z } from 'zod';
+import { getPerformanceAndVacuumSettings, toolFindTableSchema } from '~/lib/tools/dbinfo';
+import { toolDescribeTable, toolExplainQuery, toolGetSlowQueries } from '~/lib/tools/slow-queries';
+import {
+  toolCurrentActiveQueries,
+  toolGetConnectionsGroups,
+  toolGetConnectionsStats,
+  toolGetQueriesWaitingOnLocks,
+  toolGetVacuumStats
+} from '~/lib/tools/stats';
+import { ToolsetGroup } from './types';
+
+export function getDBSQLTools(connString: string): DBSQLTools {
+  return new DBSQLTools(connString);
+}
+
+// The DBSQLTools toolset provides tools for querying the postgres database
+// directly via SQL to collect system performance information.
+export class DBSQLTools implements ToolsetGroup {
+  private _connstr: string;
+
+  constructor(connString: string) {
+    this._connstr = connString;
+  }
+
+  toolset(): Record<string, Tool> {
+    return {
+      getSlowQueries: this.getSlowQueries(),
+      explainQuery: this.explainQuery(),
+      describeTable: this.describeTable(),
+      findTableSchema: this.findTableSchema(),
+      getCurrentActiveQueries: this.getCurrentActiveQueries(),
+      getQueriesWaitingOnLocks: this.getQueriesWaitingOnLocks(),
+      getVacuumStats: this.getVacuumStats(),
+      getConnectionsStats: this.getConnectionsStats(),
+      getConnectionsGroups: this.getConnectionsGroups(),
+      getPerformanceAndVacuumSettings: this.getPerformanceAndVacuumSettings()
+    };
+  }
+
+  getSlowQueries(): Tool {
+    const connstr = this._connstr;
+    return tool({
+      description: `Get a list of slow queries formatted as a JSON array. Contains how many times the query was called,
+the max execution time in seconds, the mean execution time in seconds, the total execution time
+(all calls together) in seconds, and the query itself.`,
+      parameters: z.object({}),
+      execute: async () => {
+        console.log('getSlowQueries');
+        const slowQueries = await toolGetSlowQueries(connstr, 2000);
+        console.log('slowQueries', JSON.stringify(slowQueries));
+        return JSON.stringify(slowQueries);
+      }
+    });
+  }
+
+  explainQuery(): Tool {
+    const connstr = this._connstr;
+    return tool({
+      description: `Run explain on a a query. Returns the explain plan as received from PostgreSQL.
+The query needs to be complete, it cannot contain $1, $2, etc. If you need to, replace the parameters with your own made up values.
+It's very important that $1, $2, etc. are not passed to this tool. Use the tool describeTable to get the types of the columns.
+If you know the schema, pass it in as well.`,
+      parameters: z.object({
+        schema: z.string(),
+        query: z.string()
+      }),
+      execute: async ({ schema, query }) => {
+        if (!schema) {
+          schema = 'public';
+        }
+        const explain = await toolExplainQuery(connstr, schema, query);
+        if (explain) {
+          return explain;
+        } else {
+          return 'Could not run EXPLAIN on the query';
+        }
+      }
+    });
+  }
+
+  describeTable(): Tool {
+    const connstr = this._connstr;
+    return tool({
+      description: `Describe a table. If you know the schema, pass it as a parameter. If you don't, use public.`,
+      parameters: z.object({
+        schema: z.string(),
+        table: z.string()
+      }),
+      execute: async ({ schema, table }) => {
+        if (!schema) {
+          schema = 'public';
+        }
+        return await toolDescribeTable(connstr, schema, table);
+      }
+    });
+  }
+
+  findTableSchema(): Tool {
+    const connstr = this._connstr;
+    return tool({
+      description: `Find the schema of a table. Use this tool to find the schema of a table.`,
+      parameters: z.object({
+        table: z.string()
+      }),
+      execute: async ({ table }) => {
+        return await toolFindTableSchema(connstr, table);
+      }
+    });
+  }
+
+  getCurrentActiveQueries(): Tool {
+    const connstr = this._connstr;
+    return tool({
+      description: `Get the currently active queries.`,
+      parameters: z.object({}),
+      execute: async () => {
+        return await toolCurrentActiveQueries(connstr);
+      }
+    });
+  }
+
+  getQueriesWaitingOnLocks(): Tool {
+    const connstr = this._connstr;
+    return tool({
+      description: `Get the queries that are currently blocked waiting on locks.`,
+      parameters: z.object({}),
+      execute: async () => {
+        return await toolGetQueriesWaitingOnLocks(connstr);
+      }
+    });
+  }
+
+  getVacuumStats(): Tool {
+    const connstr = this._connstr;
+    return tool({
+      description: `Get the vacuum stats for the top tables in the database. They are sorted by the number of dead tuples descending.`,
+      parameters: z.object({}),
+      execute: async () => {
+        return await toolGetVacuumStats(connstr);
+      }
+    });
+  }
+
+  getConnectionsStats(): Tool {
+    const connstr = this._connstr;
+    return tool({
+      description: `Get the connections stats for the database.`,
+      parameters: z.object({}),
+      execute: async () => {
+        return await toolGetConnectionsStats(connstr);
+      }
+    });
+  }
+
+  getConnectionsGroups(): Tool {
+    const connstr = this._connstr;
+    return tool({
+      description: `Get the connections groups for the database. This is a view in the pg_stat_activity table, grouped by (state, user, application_name, client_addr, wait_event_type, wait_event).`,
+      parameters: z.object({}),
+      execute: async () => {
+        return await toolGetConnectionsGroups(connstr);
+      }
+    });
+  }
+
+  getPerformanceAndVacuumSettings(): Tool {
+    const connstr = this._connstr;
+    return tool({
+      description: `Get the performance and vacuum settings for the database.`,
+      parameters: z.object({}),
+      execute: async () => {
+        return await getPerformanceAndVacuumSettings(connstr);
+      }
+    });
+  }
+}

--- a/apps/dbagent/src/lib/ai/tools/index.ts
+++ b/apps/dbagent/src/lib/ai/tools/index.ts
@@ -1,0 +1,5 @@
+export * from './cluster';
+export * from './common';
+export * from './db';
+export * from './playbook';
+export * from './types';

--- a/apps/dbagent/src/lib/ai/tools/playbook.ts
+++ b/apps/dbagent/src/lib/ai/tools/playbook.ts
@@ -1,0 +1,23 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { getPlaybook, listPlaybooks } from '~/lib/tools/playbooks';
+
+export const getPlaybookTool = tool({
+  description: `Get a playbook contents by name. A playbook is a list of steps to follow to achieve a goal. Follow it step by step.`,
+  parameters: z.object({
+    name: z.string()
+  }),
+  execute: async ({ name }: { name: string }) => getPlaybook(name)
+});
+
+export const listPlaybooksTool = tool({
+  description: `List the available playbooks.`,
+  parameters: z.object({}),
+  execute: async () => listPlaybooks()
+});
+
+// The playbookToolset provides agent tools for accessing available playbooks.
+export const playbookToolset = {
+  getPlaybookTool,
+  listPlaybooksTool
+};

--- a/apps/dbagent/src/lib/ai/tools/types.ts
+++ b/apps/dbagent/src/lib/ai/tools/types.ts
@@ -1,0 +1,21 @@
+import { Tool } from 'ai';
+
+export interface ToolsetGroup {
+  toolset(): Record<string, Tool>;
+}
+
+export type ToolsetBuilderFunction = () => Record<string, Tool>;
+
+export type Toolset = ToolsetGroup | ToolsetBuilderFunction | Record<string, Tool>;
+
+export function mergeToolsets(...toolsets: Toolset[]): Record<string, Tool> {
+  const sets: Record<string, Tool>[] = toolsets.map((toolset) => {
+    if (typeof toolset === 'function') {
+      return toolset();
+    } else if ('toolset' in toolset) {
+      return (toolset as ToolsetGroup).toolset();
+    }
+    return toolset;
+  });
+  return sets.reduce((acc, tool) => ({ ...acc, ...tool }), {});
+}

--- a/apps/dbagent/src/lib/tools/dbinfo.ts
+++ b/apps/dbagent/src/lib/tools/dbinfo.ts
@@ -23,9 +23,9 @@ ${JSON.stringify(project)}
   }
 }
 
-export async function getPerformanceAndVacuumSettings(connection: Connection): Promise<string> {
-  const performanceSettings = await getPerformanceSettings(connection.connectionString);
-  const vacuumSettings = await getVacuumSettings(connection.connectionString);
+export async function getPerformanceAndVacuumSettings(connString: string): Promise<string> {
+  const performanceSettings = await getPerformanceSettings(connString);
+  const vacuumSettings = await getVacuumSettings(connString);
 
   return `
 Performance settings: ${JSON.stringify(performanceSettings)}


### PR DESCRIPTION
We already have a number of tools. Some tools accessing playbooks, the target DB and others to access AWS cluster information.

This changes splits the getTools function and groups tools according to the resources they interact with. This will allow us to selectively build tools. For example ignore the AWS based tools if the AWS cluster configuration is missing, or introduce support for other providers like GCP.