### PR TITLE
TargetDB tools connection reuse + concurrency limit

### DIFF
--- a/apps/dbagent/src/app/api/chat/route.ts
+++ b/apps/dbagent/src/app/api/chat/route.ts
@@ -37,13 +37,17 @@ export async function POST(req: Request) {
 
     const modelInstance = getModelInstance(model);
 
+    const { tools, end } = await getTools(connection);
     const result = streamText({
       model: modelInstance,
       messages,
       system: context,
-      tools: await getTools(connection),
+      tools: tools,
       maxSteps: 20,
-      toolCallStreaming: true
+      toolCallStreaming: true,
+      onFinish: async (_result) => {
+        await end();
+      }
     });
 
     return result.toDataStreamResponse({

--- a/apps/dbagent/src/evals/lib/chat-runner.ts
+++ b/apps/dbagent/src/evals/lib/chat-runner.ts
@@ -4,7 +4,6 @@ import { ExpectStatic } from 'vitest';
 import { chatSystemPrompt, getModelInstance, getTools } from '~/lib/ai/aidba';
 import { Connection } from '~/lib/db/connections';
 import { env } from '~/lib/env/eval';
-import { getTargetDbConnection } from '~/lib/targetdb/db';
 import { traceVercelAiResponse } from './trace';
 
 export const evalChat = async ({
@@ -23,18 +22,19 @@ export const evalChat = async ({
     projectId: 'projectId',
     isDefault: true
   };
-  const targetClient = await getTargetDbConnection(dbConnection);
+
+  const { tools, end } = await getTools(connection);
   try {
     const response = await generateText({
       model: getModelInstance(env.CHAT_MODEL),
       system: chatSystemPrompt,
-      tools: await getTools(connection),
-      messages,
-      maxSteps: 20
+      maxSteps: 20,
+      tools,
+      messages
     });
     traceVercelAiResponse(response, expect);
     return response;
   } finally {
-    await targetClient.end();
+    await end();
   }
 };

--- a/apps/dbagent/src/lib/ai/aidba.ts
+++ b/apps/dbagent/src/lib/ai/aidba.ts
@@ -35,11 +35,7 @@ interface DBTools {
   end: () => Promise<void>;
 }
 
-export async function getTools(
-  connection: Connection,
-  asUserId?: string,
-  asProjectId?: string
-): Promise<DBTools> {
+export async function getTools(connection: Connection, asUserId?: string, asProjectId?: string): Promise<DBTools> {
   const dbTools = getDBSQLTools(connection.connectionString);
   const clusterTools = getDBClusterTools(connection, asUserId);
   const playbookToolset = getPlaybookToolset(connection.projectId, asUserId, asProjectId);

--- a/apps/dbagent/src/lib/ai/aidba.ts
+++ b/apps/dbagent/src/lib/ai/aidba.ts
@@ -30,15 +30,25 @@ Then use the contents of the playbook as an action plan. Execute the plan step b
 At the end of your execution, print a summary of the results.
 `;
 
+interface DBTools {
+  tools: Record<string, Tool>;
+  end: () => Promise<void>;
+}
+
 export async function getTools(
   connection: Connection,
   asUserId?: string,
   asProjectId?: string
-): Promise<Record<string, Tool>> {
+): Promise<DBTools> {
   const dbTools = getDBSQLTools(connection.connectionString);
   const clusterTools = getDBClusterTools(connection, asUserId);
   const playbookToolset = getPlaybookToolset(connection.projectId, asUserId, asProjectId);
-  return mergeToolsets(commonToolset, playbookToolset, dbTools, clusterTools);
+  return {
+    tools: mergeToolsets(commonToolset, playbookToolset, dbTools, clusterTools),
+    end: async () => {
+      await dbTools.end();
+    }
+  };
 }
 
 export function getModelInstance(model: string): LanguageModelV1 {

--- a/apps/dbagent/src/lib/ai/tools/db.ts
+++ b/apps/dbagent/src/lib/ai/tools/db.ts
@@ -11,17 +11,25 @@ import {
 } from '~/lib/tools/stats';
 import { ToolsetGroup } from './types';
 
+import { getTargetDbPool, Pool, withPoolConnection } from '~/lib/targetdb/db';
+
 export function getDBSQLTools(connString: string): DBSQLTools {
-  return new DBSQLTools(connString);
+  const pool = getTargetDbPool(connString);
+  return new DBSQLTools(pool);
 }
 
 // The DBSQLTools toolset provides tools for querying the postgres database
 // directly via SQL to collect system performance information.
 export class DBSQLTools implements ToolsetGroup {
-  private _connstr: string;
+  private _pool: Pool | (() => Promise<Pool>);
 
-  constructor(connString: string) {
-    this._connstr = connString;
+  constructor(pool: Pool | (() => Promise<Pool>)) {
+    this._pool = pool;
+  }
+
+  async end() {
+    const pool = typeof this._pool === 'function' ? await this._pool() : this._pool;
+    await pool.end();
   }
 
   toolset(): Record<string, Tool> {
@@ -40,7 +48,7 @@ export class DBSQLTools implements ToolsetGroup {
   }
 
   getSlowQueries(): Tool {
-    const connstr = this._connstr;
+    const pool = this._pool;
     return tool({
       description: `Get a list of slow queries formatted as a JSON array. Contains how many times the query was called,
 the max execution time in seconds, the mean execution time in seconds, the total execution time
@@ -48,7 +56,7 @@ the max execution time in seconds, the mean execution time in seconds, the total
       parameters: z.object({}),
       execute: async () => {
         console.log('getSlowQueries');
-        const slowQueries = await toolGetSlowQueries(connstr, 2000);
+        const slowQueries = await withPoolConnection(pool, async (client) => await toolGetSlowQueries(client, 2000));
         console.log('slowQueries', JSON.stringify(slowQueries));
         return JSON.stringify(slowQueries);
       }
@@ -56,7 +64,7 @@ the max execution time in seconds, the mean execution time in seconds, the total
   }
 
   explainQuery(): Tool {
-    const connstr = this._connstr;
+    const pool = this._pool;
     return tool({
       description: `Run explain on a a query. Returns the explain plan as received from PostgreSQL.
 The query needs to be complete, it cannot contain $1, $2, etc. If you need to, replace the parameters with your own made up values.
@@ -70,7 +78,7 @@ If you know the schema, pass it in as well.`,
         if (!schema) {
           schema = 'public';
         }
-        const explain = await toolExplainQuery(connstr, schema, query);
+        const explain = await withPoolConnection(pool, async (client) => await toolExplainQuery(client, schema, query));
         if (explain) {
           return explain;
         } else {
@@ -81,7 +89,7 @@ If you know the schema, pass it in as well.`,
   }
 
   describeTable(): Tool {
-    const connstr = this._connstr;
+    const pool = this._pool;
     return tool({
       description: `Describe a table. If you know the schema, pass it as a parameter. If you don't, use public.`,
       parameters: z.object({
@@ -92,86 +100,86 @@ If you know the schema, pass it in as well.`,
         if (!schema) {
           schema = 'public';
         }
-        return await toolDescribeTable(connstr, schema, table);
+        return await withPoolConnection(pool, async (client) => await toolDescribeTable(client, schema, table));
       }
     });
   }
 
   findTableSchema(): Tool {
-    const connstr = this._connstr;
+    const pool = this._pool;
     return tool({
       description: `Find the schema of a table. Use this tool to find the schema of a table.`,
       parameters: z.object({
         table: z.string()
       }),
       execute: async ({ table }) => {
-        return await toolFindTableSchema(connstr, table);
+        return await withPoolConnection(pool, async (client) => await toolFindTableSchema(client, table));
       }
     });
   }
 
   getCurrentActiveQueries(): Tool {
-    const connstr = this._connstr;
+    const pool = this._pool;
     return tool({
       description: `Get the currently active queries.`,
       parameters: z.object({}),
       execute: async () => {
-        return await toolCurrentActiveQueries(connstr);
+        return await withPoolConnection(pool, toolCurrentActiveQueries);
       }
     });
   }
 
   getQueriesWaitingOnLocks(): Tool {
-    const connstr = this._connstr;
+    const pool = this._pool;
     return tool({
       description: `Get the queries that are currently blocked waiting on locks.`,
       parameters: z.object({}),
       execute: async () => {
-        return await toolGetQueriesWaitingOnLocks(connstr);
+        return await withPoolConnection(pool, toolGetQueriesWaitingOnLocks);
       }
     });
   }
 
   getVacuumStats(): Tool {
-    const connstr = this._connstr;
+    const pool = this._pool;
     return tool({
       description: `Get the vacuum stats for the top tables in the database. They are sorted by the number of dead tuples descending.`,
       parameters: z.object({}),
       execute: async () => {
-        return await toolGetVacuumStats(connstr);
+        return await withPoolConnection(pool, toolGetVacuumStats);
       }
     });
   }
 
   getConnectionsStats(): Tool {
-    const connstr = this._connstr;
+    const pool = this._pool;
     return tool({
       description: `Get the connections stats for the database.`,
       parameters: z.object({}),
       execute: async () => {
-        return await toolGetConnectionsStats(connstr);
+        return await withPoolConnection(pool, toolGetConnectionsStats);
       }
     });
   }
 
   getConnectionsGroups(): Tool {
-    const connstr = this._connstr;
+    const pool = this._pool;
     return tool({
       description: `Get the connections groups for the database. This is a view in the pg_stat_activity table, grouped by (state, user, application_name, client_addr, wait_event_type, wait_event).`,
       parameters: z.object({}),
       execute: async () => {
-        return await toolGetConnectionsGroups(connstr);
+        return await withPoolConnection(pool, toolGetConnectionsGroups);
       }
     });
   }
 
   getPerformanceAndVacuumSettings(): Tool {
-    const connstr = this._connstr;
+    const pool = this._pool;
     return tool({
       description: `Get the performance and vacuum settings for the database.`,
       parameters: z.object({}),
       execute: async () => {
-        return await getPerformanceAndVacuumSettings(connstr);
+        return await withPoolConnection(pool, getPerformanceAndVacuumSettings);
       }
     });
   }

--- a/apps/dbagent/src/lib/targetdb/db.ts
+++ b/apps/dbagent/src/lib/targetdb/db.ts
@@ -1,8 +1,32 @@
-import { Client } from 'pg';
+import pg from 'pg';
+
+export type PoolConfig = pg.PoolConfig;
+export type Pool = pg.Pool;
+export type Client = pg.Client;
+export type ClientBase = pg.ClientBase;
+
+export function getTargetDbPool(connectionString: string, poolConfig?: Omit<PoolConfig, 'connectionString'>): Pool {
+  const parsed = parseConnectionString(connectionString);
+  const config = {
+    ...(poolConfig || {}),
+    ...parsed
+  };
+  if (!config.min) config.min = 0;
+  if (!config.max) config.max = 1;
+
+  return new pg.Pool(config);
+}
 
 export async function getTargetDbConnection(connectionString: string): Promise<Client> {
+  const parsed = parseConnectionString(connectionString);
+  const client = new pg.Client({ ...parsed });
+  await client.connect();
+  return client;
+}
+
+function parseConnectionString(connectionString: string): { connectionString: string; ssl?: pg.ClientConfig['ssl'] } {
   let modifiedConnectionString = connectionString;
-  let sslConfig = undefined;
+  let sslConfig: pg.ClientConfig['ssl'] | undefined = undefined;
   if (connectionString.includes('sslmode=require')) {
     // Remove sslmode=require from connection string to avoid duplicate SSL config
     modifiedConnectionString = connectionString.replace(/[\s;]?sslmode=require/g, '');
@@ -10,13 +34,35 @@ export async function getTargetDbConnection(connectionString: string): Promise<C
       rejectUnauthorized: false // Allow self-signed certificates
     };
   }
-  const client = new Client({
+  return {
     connectionString: modifiedConnectionString,
     ssl: sslConfig
-  });
+  };
+}
 
-  await client.connect();
-  return client;
+export async function withPoolConnection<T>(
+  pool: Pool | (() => Promise<Pool>),
+  fn: (client: ClientBase) => Promise<T>
+): Promise<T> {
+  const poolInstance = typeof pool === 'function' ? await pool() : pool;
+  const client = await poolInstance.connect();
+  try {
+    return await fn(client);
+  } finally {
+    client.release();
+  }
+}
+
+export async function withTargetDbConnection<T>(
+  connectionString: string,
+  fn: (client: ClientBase) => Promise<T>
+): Promise<T> {
+  const client = await getTargetDbConnection(connectionString);
+  try {
+    return await fn(client);
+  } finally {
+    await client.end();
+  }
 }
 
 export interface TableStat {
@@ -31,10 +77,8 @@ export interface TableStat {
   nTupDel: number;
 }
 
-export async function getTableStats(connString: string): Promise<TableStat[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query(`
+export async function getTableStats(client: ClientBase): Promise<TableStat[]> {
+  const result = await client.query(`
     SELECT
         c.oid AS oid,
         t.table_name AS name,
@@ -66,20 +110,17 @@ export async function getTableStats(connString: string): Promise<TableStat[]> {
     LIMIT 100;
 `);
 
-    return result.rows.map((row) => ({
-      schema: row.schema,
-      name: row.name,
-      rows: parseInt(row.rows),
-      size: row.size,
-      seqScans: parseInt(row.seq_scan),
-      idxScans: parseInt(row.idx_scan),
-      nTupIns: parseInt(row.n_tup_ins),
-      nTupUpd: parseInt(row.n_tup_upd),
-      nTupDel: parseInt(row.n_tup_del)
-    }));
-  } finally {
-    await client.end();
-  }
+  return result.rows.map((row) => ({
+    schema: row.schema,
+    name: row.name,
+    rows: parseInt(row.rows),
+    size: row.size,
+    seqScans: parseInt(row.seq_scan),
+    idxScans: parseInt(row.idx_scan),
+    nTupIns: parseInt(row.n_tup_ins),
+    nTupUpd: parseInt(row.n_tup_upd),
+    nTupDel: parseInt(row.n_tup_del)
+  }));
 }
 
 export interface PgExtension {
@@ -88,20 +129,15 @@ export interface PgExtension {
   installed_version: string;
 }
 
-export async function getExtensions(connString: string): Promise<PgExtension[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query('SELECT name, default_version, installed_version FROM pg_available_extensions');
+export async function getExtensions(client: ClientBase): Promise<PgExtension[]> {
+  const result = await client.query('SELECT name, default_version, installed_version FROM pg_available_extensions');
 
-    // Sort installed extensions to the top
-    return result.rows.sort((a, b) => {
-      if (a.installed_version && !b.installed_version) return -1;
-      if (!a.installed_version && b.installed_version) return 1;
-      return a.name.localeCompare(b.name);
-    });
-  } finally {
-    await client.end();
-  }
+  // Sort installed extensions to the top
+  return result.rows.sort((a, b) => {
+    if (a.installed_version && !b.installed_version) return -1;
+    if (!a.installed_version && b.installed_version) return 1;
+    return a.name.localeCompare(b.name);
+  });
 }
 
 export interface PerformanceSetting {
@@ -112,10 +148,8 @@ export interface PerformanceSetting {
   description: string;
 }
 
-export async function getPerformanceSettings(connString: string): Promise<PerformanceSetting[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query(`
+export async function getPerformanceSettings(client: ClientBase): Promise<PerformanceSetting[]> {
+  const result = await client.query(`
       SELECT 
         name,
         setting,
@@ -144,16 +178,11 @@ export async function getPerformanceSettings(connString: string): Promise<Perfor
         'huge_pages'
       )
     `);
-    return result.rows;
-  } finally {
-    await client.end();
-  }
+  return result.rows;
 }
 
-export async function getVacuumSettings(connString: string): Promise<PerformanceSetting[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query(`
+export async function getVacuumSettings(client: ClientBase): Promise<PerformanceSetting[]> {
+  const result = await client.query(`
       SELECT 
         name,
         setting,
@@ -170,10 +199,7 @@ export async function getVacuumSettings(connString: string): Promise<Performance
         'track_counts'
       );
     `);
-    return result.rows;
-  } finally {
-    await client.end();
-  }
+  return result.rows;
 }
 
 export interface ActiveQuery {
@@ -185,10 +211,8 @@ export interface ActiveQuery {
   wait_event: string | null;
 }
 
-export async function getCurrentActiveQueries(connString: string): Promise<ActiveQuery[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query(`
+export async function getCurrentActiveQueries(client: ClientBase): Promise<ActiveQuery[]> {
+  const result = await client.query(`
       SELECT 
         pid,
         state,
@@ -202,10 +226,7 @@ export async function getCurrentActiveQueries(connString: string): Promise<Activ
       ORDER BY duration DESC 
       LIMIT 500;
     `);
-    return result.rows;
-  } finally {
-    await client.end();
-  }
+  return result.rows;
 }
 
 export interface BlockedQuery {
@@ -216,10 +237,8 @@ export interface BlockedQuery {
   blocked_duration: number;
 }
 
-export async function getQueriesWaitingOnLocks(connString: string): Promise<BlockedQuery[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query(`
+export async function getQueriesWaitingOnLocks(client: ClientBase): Promise<BlockedQuery[]> {
+  const result = await client.query(`
       WITH blocked_queries AS (
         SELECT 
           blocked.pid as blocked_pid,
@@ -246,10 +265,7 @@ export async function getQueriesWaitingOnLocks(connString: string): Promise<Bloc
       )
       SELECT * FROM blocked_queries ORDER BY blocked_duration DESC;
     `);
-    return result.rows;
-  } finally {
-    await client.end();
-  }
+  return result.rows;
 }
 
 export interface VacuumStats {
@@ -264,10 +280,8 @@ export interface VacuumStats {
   modifications_since_analyze: number;
 }
 
-export async function getVacuumStats(connString: string): Promise<VacuumStats[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query(`
+export async function getVacuumStats(client: ClientBase): Promise<VacuumStats[]> {
+  const result = await client.query(`
       SELECT
         schemaname,
         relname as table_name,
@@ -282,10 +296,7 @@ export async function getVacuumStats(connString: string): Promise<VacuumStats[]>
       ORDER BY n_dead_tup DESC
       LIMIT 50;
     `);
-    return result.rows;
-  } finally {
-    await client.end();
-  }
+  return result.rows;
 }
 
 export interface ConnectionsStats {
@@ -295,12 +306,10 @@ export interface ConnectionsStats {
   connections_utilization_pctg: number;
 }
 
-export async function getConnectionsStats(connString: string): Promise<ConnectionsStats[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query(`
-SELECT
-    A.total_connections,
+export async function getConnectionsStats(client: ClientBase): Promise<ConnectionsStats[]> {
+  const result = await client.query(`
+    SELECT
+        A.total_connections,
     A.non_idle_connections,
     B.max_connections,
     round((100 * A.total_connections::numeric / B.max_connections::numeric), 2) connections_utilization_pctg
@@ -308,10 +317,7 @@ FROM
     (select count(1) as total_connections, sum(case when state!='idle' then 1 else 0 end) as non_idle_connections from pg_stat_activity) A,
     (select setting as max_connections from pg_settings where name='max_connections') B;
 `);
-    return result.rows;
-  } finally {
-    await client.end();
-  }
+  return result.rows;
 }
 
 export interface ConnectionDetails {
@@ -324,10 +330,8 @@ export interface ConnectionDetails {
   wait_event: string;
 }
 
-export async function getConnectionsGroups(connString: string): Promise<ConnectionDetails[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query(`
+export async function getConnectionsGroups(client: ClientBase): Promise<ConnectionDetails[]> {
+  const result = await client.query(`
 SELECT 
     count(*) AS total_connections,
     state,
@@ -345,22 +349,14 @@ GROUP BY
     wait_event_type, 
     wait_event
 ORDER BY total_connections DESC;`);
-    return result.rows;
-  } finally {
-    await client.end();
-  }
+  return result.rows;
 }
 
-export async function getOldestIdleConnections(connString: string): Promise<ConnectionDetails[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query(`
+export async function getOldestIdleConnections(client: ClientBase): Promise<ConnectionDetails[]> {
+  const result = await client.query(`
       SELECT * FROM pg_stat_activity WHERE state = 'idle' ORDER BY query_start ASC LIMIT 10;
     `);
-    return result.rows;
-  } finally {
-    await client.end();
-  }
+  return result.rows;
 }
 
 interface SlowQuery {
@@ -371,10 +367,8 @@ interface SlowQuery {
   query: string;
 }
 
-export async function getSlowQueries(connString: string, thresholdMs: number): Promise<SlowQuery[]> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const query = `
+export async function getSlowQueries(client: ClientBase, thresholdMs: number): Promise<SlowQuery[]> {
+  const query = `
     SELECT 
       calls,
       round(max_exec_time/1000) max_exec_secs,
@@ -386,15 +380,11 @@ export async function getSlowQueries(connString: string, thresholdMs: number): P
     ORDER BY total_exec_time DESC 
     LIMIT 10;
   `;
-    const result = await client.query(query, [thresholdMs]);
-    return result.rows;
-  } finally {
-    await client.end();
-  }
+  const result = await client.query(query, [thresholdMs]);
+  return result.rows;
 }
 
-export async function explainQuery(connString: string, schema: string, query: string): Promise<string> {
-  const client = await getTargetDbConnection(connString);
+export async function explainQuery(client: ClientBase, schema: string, query: string): Promise<string> {
   if (query.includes('$1') || query.includes('$2') || query.includes('$3') || query.includes('$4')) {
     return 'The query seems to contain placeholders ($1, $2, etc). Replace them with actual values and try again.';
   }
@@ -413,11 +403,10 @@ export async function explainQuery(connString: string, schema: string, query: st
     toReturn = 'I could not run EXPLAIN on that query. Try a different method.';
   }
   await client.query('ROLLBACK');
-  await client.end();
   return toReturn;
 }
 
-export async function describeTable(connString: string, schema: string, table: string): Promise<string> {
+export async function describeTable(client: ClientBase, schema: string, table: string): Promise<string> {
   console.log('schema', schema);
   console.log('table', table);
   // Get column information
@@ -461,47 +450,37 @@ export async function describeTable(connString: string, schema: string, table: s
     ORDER BY
       i.relname;
   `;
-  const client = await getTargetDbConnection(connString);
-  try {
-    const columns = await client.query(columnQuery, [schema, table]);
-    const indexes = await client.query(indexQuery, [table, schema]);
+  const columns = await client.query(columnQuery, [schema, table]);
+  const indexes = await client.query(indexQuery, [table, schema]);
 
-    let description = `Table: ${schema}.${table}\n\nColumns:\n`;
+  let description = `Table: ${schema}.${table}\n\nColumns:\n`;
 
-    columns.rows.forEach((col: any) => {
-      description += `${col.column_name} ${col.data_type}`;
-      description += col.is_nullable === 'YES' ? ' NULL' : ' NOT NULL';
-      if (col.column_default) {
-        description += ` DEFAULT ${col.column_default}`;
-      }
-      description += '\n';
-    });
+  columns.rows.forEach((col: any) => {
+    description += `${col.column_name} ${col.data_type}`;
+    description += col.is_nullable === 'YES' ? ' NULL' : ' NOT NULL';
+    if (col.column_default) {
+      description += ` DEFAULT ${col.column_default}`;
+    }
+    description += '\n';
+  });
 
-    description += '\nIndexes:\n';
-    indexes.rows.forEach((idx: any) => {
-      description += `${idx.index_name} ON (${idx.column_names})`;
-      if (idx.is_primary) {
-        description += ' PRIMARY KEY';
-      } else if (idx.is_unique) {
-        description += ' UNIQUE';
-      }
-      description += '\n';
-    });
+  description += '\nIndexes:\n';
+  indexes.rows.forEach((idx: any) => {
+    description += `${idx.index_name} ON (${idx.column_names})`;
+    if (idx.is_primary) {
+      description += ' PRIMARY KEY';
+    } else if (idx.is_unique) {
+      description += ' UNIQUE';
+    }
+    description += '\n';
+  });
 
-    return description;
-  } catch (error) {
-    console.error('Error describing table', error);
-    return `Could not describe table ${schema}.${table}`;
-  } finally {
-    await client.end();
-  }
+  return description;
 }
 
-export async function findTableSchema(connString: string, table: string): Promise<string> {
-  const client = await getTargetDbConnection(connString);
-  try {
-    const result = await client.query(
-      `
+export async function findTableSchema(client: ClientBase, table: string): Promise<string> {
+  const result = await client.query(
+    `
       SELECT 
       schemaname as schema,
       pg_total_relation_size(schemaname || '.' || tablename) as total_bytes
@@ -510,13 +489,10 @@ export async function findTableSchema(connString: string, table: string): Promis
     ORDER BY total_bytes DESC
     LIMIT 1;
   `,
-      [table]
-    );
-    if (result.rows.length === 0) {
-      return 'public'; // Default to public if no match found
-    }
-    return result.rows[0].schema;
-  } finally {
-    await client.end();
+    [table]
+  );
+  if (result.rows.length === 0) {
+    return 'public'; // Default to public if no match found
   }
+  return result.rows[0].schema;
 }

--- a/apps/dbagent/src/lib/tools/dbinfo.ts
+++ b/apps/dbagent/src/lib/tools/dbinfo.ts
@@ -1,7 +1,7 @@
 import { getConnectionInfo } from '../db/connection-info';
 import { Connection } from '../db/connections';
 import { getProjectById } from '../db/projects';
-import { findTableSchema, getPerformanceSettings, getVacuumSettings } from '../targetdb/db';
+import { ClientBase, findTableSchema, getPerformanceSettings, getVacuumSettings } from '../targetdb/db';
 
 export async function getTablesAndInstanceInfo(connection: Connection, asUserId?: string): Promise<string> {
   try {
@@ -23,9 +23,9 @@ ${JSON.stringify(project)}
   }
 }
 
-export async function getPerformanceAndVacuumSettings(connString: string): Promise<string> {
-  const performanceSettings = await getPerformanceSettings(connString);
-  const vacuumSettings = await getVacuumSettings(connString);
+export async function getPerformanceAndVacuumSettings(client: ClientBase): Promise<string> {
+  const performanceSettings = await getPerformanceSettings(client);
+  const vacuumSettings = await getVacuumSettings(client);
 
   return `
 Performance settings: ${JSON.stringify(performanceSettings)}
@@ -38,9 +38,9 @@ export async function getPostgresExtensions(connection: Connection, asUserId?: s
   return `Extensions: ${JSON.stringify(extensions)}`;
 }
 
-export async function toolFindTableSchema(connString: string, tableName: string): Promise<string> {
+export async function toolFindTableSchema(client: ClientBase, tableName: string): Promise<string> {
   try {
-    const result = await findTableSchema(connString, tableName);
+    const result = await findTableSchema(client, tableName);
     return result;
   } catch (error) {
     console.error('Error finding schema for table', error);

--- a/apps/dbagent/src/lib/tools/slow-queries.ts
+++ b/apps/dbagent/src/lib/tools/slow-queries.ts
@@ -1,18 +1,18 @@
-import { describeTable, explainQuery, getSlowQueries } from '../targetdb/db';
+import { ClientBase, describeTable, explainQuery, getSlowQueries } from '../targetdb/db';
 
-export async function toolGetSlowQueries(connString: string, thresholdMs: number): Promise<string> {
-  const slowQueries = await getSlowQueries(connString, thresholdMs);
+export async function toolGetSlowQueries(client: ClientBase, thresholdMs: number): Promise<string> {
+  const slowQueries = await getSlowQueries(client, thresholdMs);
   const result = JSON.stringify(slowQueries);
   console.log(result);
   return JSON.stringify(slowQueries);
 }
 
-export async function toolExplainQuery(connString: string, schema: string, query: string): Promise<string> {
-  const result = await explainQuery(connString, schema, query);
-  return result;
+export async function toolExplainQuery(client: ClientBase, schema: string, query: string): Promise<string> {
+  const result = await explainQuery(client, schema, query);
+  return JSON.stringify(result);
 }
 
-export async function toolDescribeTable(connString: string, schema: string, table: string): Promise<string> {
-  const result = await describeTable(connString, schema, table);
-  return result;
+export async function toolDescribeTable(client: ClientBase, schema: string, table: string): Promise<string> {
+  const result = await describeTable(client, schema, table);
+  return JSON.stringify(result);
 }

--- a/apps/dbagent/src/lib/tools/stats.ts
+++ b/apps/dbagent/src/lib/tools/stats.ts
@@ -1,4 +1,5 @@
 import {
+  ClientBase,
   getConnectionsGroups,
   getConnectionsStats,
   getCurrentActiveQueries,
@@ -6,36 +7,36 @@ import {
   getVacuumStats
 } from '../targetdb/db';
 
-export async function toolCurrentActiveQueries(connString: string): Promise<string> {
-  const activeQueries = await getCurrentActiveQueries(connString);
+export async function toolCurrentActiveQueries(client: ClientBase): Promise<string> {
+  const activeQueries = await getCurrentActiveQueries(client);
   const result = JSON.stringify(activeQueries);
   console.log(result);
   return result;
 }
 
-export async function toolGetQueriesWaitingOnLocks(connString: string): Promise<string> {
-  const blockedQueries = await getQueriesWaitingOnLocks(connString);
+export async function toolGetQueriesWaitingOnLocks(client: ClientBase): Promise<string> {
+  const blockedQueries = await getQueriesWaitingOnLocks(client);
   const result = JSON.stringify(blockedQueries);
   console.log(result);
   return result;
 }
 
-export async function toolGetVacuumStats(connString: string): Promise<string> {
-  const vacuumStats = await getVacuumStats(connString);
+export async function toolGetVacuumStats(client: ClientBase): Promise<string> {
+  const vacuumStats = await getVacuumStats(client);
   const result = JSON.stringify(vacuumStats);
   console.log(result);
   return result;
 }
 
-export async function toolGetConnectionsStats(connString: string): Promise<string> {
-  const stats = await getConnectionsStats(connString);
+export async function toolGetConnectionsStats(client: ClientBase): Promise<string> {
+  const stats = await getConnectionsStats(client);
   const result = JSON.stringify(stats);
   console.log(result);
   return result;
 }
 
-export async function toolGetConnectionsGroups(connString: string): Promise<string> {
-  const groups = await getConnectionsGroups(connString);
+export async function toolGetConnectionsGroups(client: ClientBase): Promise<string> {
+  const groups = await getConnectionsGroups(client);
   const result = JSON.stringify(groups);
   console.log(result);
   return result;


### PR DESCRIPTION
We introduce connection pool for tools accessing the target DB.

The connection pool only creates a connection on demand, but ensures that the connection is reused between tool calls. In case the model opts for parallel tool calls the connection pool also ensures that we have a bounded number of connections to the target DB. 

For now the connection pool is only active for a single request. There is currently no concurrency limit. To limit the number of concurrently active agent->DB connections one might use pgbouncer or similar tools.