### PR TITLE
local DB access interface

### DIFF
--- a/apps/dbagent/src/app/(main)/projects/[project]/actions.ts
+++ b/apps/dbagent/src/app/(main)/projects/[project]/actions.ts
@@ -1,0 +1,63 @@
+'use server';
+
+import { getConnection, getConnectionByName, getDefaultConnection, listConnections } from '~/lib/db/connections';
+import { getUserSessionDBAccess } from '~/lib/db/db';
+import { getProjectById } from '~/lib/db/projects';
+import {
+  deleteSchedule,
+  getSchedule,
+  getSchedulesByProjectId,
+  insertSchedule,
+  updateSchedule,
+  type Schedule
+} from '~/lib/db/schedules';
+
+export async function getProject(projectId: string) {
+  const dbAccess = await getUserSessionDBAccess();
+  return getProjectById(dbAccess, projectId);
+}
+
+export async function getProjectConnectionList(projectId: string) {
+  const dbAccess = await getUserSessionDBAccess();
+  return listConnections(dbAccess, projectId);
+}
+
+export async function getDefaultProjectConnection(projectId: string) {
+  const dbAccess = await getUserSessionDBAccess();
+  return getDefaultConnection(dbAccess, projectId);
+}
+
+export async function getProjectConnection(connectionId: string) {
+  const dbAccess = await getUserSessionDBAccess();
+  return getConnection(dbAccess, connectionId);
+}
+
+export async function getProjectConnectionByName(projectId: string, name: string) {
+  const db = await getUserSessionDBAccess();
+  return getConnectionByName(db, projectId, name);
+}
+
+export async function getProjectSchedules(projectId: string) {
+  const db = await getUserSessionDBAccess();
+  return await getSchedulesByProjectId(db, projectId);
+}
+
+export async function getProjectSchedule(scheduleId: string) {
+  const db = await getUserSessionDBAccess();
+  return getSchedule(db, scheduleId);
+}
+
+export async function createProjectSchedule(schedule: Omit<Schedule, 'id'>) {
+  const db = await getUserSessionDBAccess();
+  return insertSchedule(db, schedule);
+}
+
+export async function updateProjectSchedule(schedule: Schedule) {
+  const db = await getUserSessionDBAccess();
+  return updateSchedule(db, schedule);
+}
+
+export async function deleteProjectSchedule(scheduleId: string) {
+  const db = await getUserSessionDBAccess();
+  return deleteSchedule(db, scheduleId);
+}

--- a/apps/dbagent/src/app/(main)/projects/[project]/actions.ts
+++ b/apps/dbagent/src/app/(main)/projects/[project]/actions.ts
@@ -33,31 +33,31 @@ export async function getProjectConnection(connectionId: string) {
 }
 
 export async function getProjectConnectionByName(projectId: string, name: string) {
-  const db = await getUserSessionDBAccess();
-  return getConnectionByName(db, projectId, name);
+  const dbAccess = await getUserSessionDBAccess();
+  return getConnectionByName(dbAccess, projectId, name);
 }
 
 export async function getProjectSchedules(projectId: string) {
-  const db = await getUserSessionDBAccess();
-  return await getSchedulesByProjectId(db, projectId);
+  const dbAccess = await getUserSessionDBAccess();
+  return await getSchedulesByProjectId(dbAccess, projectId);
 }
 
 export async function getProjectSchedule(scheduleId: string) {
-  const db = await getUserSessionDBAccess();
-  return getSchedule(db, scheduleId);
+  const dbAccess = await getUserSessionDBAccess();
+  return getSchedule(dbAccess, scheduleId);
 }
 
 export async function createProjectSchedule(schedule: Omit<Schedule, 'id'>) {
-  const db = await getUserSessionDBAccess();
-  return insertSchedule(db, schedule);
+  const dbAccess = await getUserSessionDBAccess();
+  return insertSchedule(dbAccess, schedule);
 }
 
 export async function updateProjectSchedule(schedule: Schedule) {
-  const db = await getUserSessionDBAccess();
-  return updateSchedule(db, schedule);
+  const dbAccess = await getUserSessionDBAccess();
+  return updateSchedule(dbAccess, schedule);
 }
 
 export async function deleteProjectSchedule(scheduleId: string) {
-  const db = await getUserSessionDBAccess();
-  return deleteSchedule(db, scheduleId);
+  const dbAccess = await getUserSessionDBAccess();
+  return deleteSchedule(dbAccess, scheduleId);
 }

--- a/apps/dbagent/src/app/(main)/projects/[project]/chats/page.tsx
+++ b/apps/dbagent/src/app/(main)/projects/[project]/chats/page.tsx
@@ -1,6 +1,6 @@
+import { getProjectConnectionList } from '~/app/(main)/projects/[project]/actions';
 import { actionGetScheduleRun } from '~/components/chats/actions';
 import { ChatsUI } from '~/components/chats/chats-ui';
-import { listConnections } from '~/lib/db/connections';
 
 type PageParams = {
   project: string;
@@ -20,7 +20,7 @@ export default async function Page({
   const { project } = await params;
   const { runId } = await searchParams;
 
-  const connections = await listConnections(project);
+  const connections = await getProjectConnectionList(project);
   const scheduleRun = await actionGetScheduleRun(runId);
 
   return <ChatsUI connections={connections} scheduleRun={scheduleRun} />;

--- a/apps/dbagent/src/app/(main)/projects/[project]/layout.tsx
+++ b/apps/dbagent/src/app/(main)/projects/[project]/layout.tsx
@@ -2,7 +2,7 @@ import { SidebarInset } from '@internal/components';
 import { notFound } from 'next/navigation';
 import { getCompletedTaskPercentage } from '~/components/onboarding/actions';
 import { SideNav } from '~/components/ui/side-nav';
-import { getProjectById } from '~/lib/db/projects';
+import { getProject } from './actions';
 
 type LayoutParams = {
   project: string;
@@ -17,7 +17,7 @@ export default async function Layout({
 }) {
   const { project: projectId } = await params;
 
-  const project = await getProjectById(projectId);
+  const project = await getProject(projectId);
   if (!project) {
     return notFound();
   }

--- a/apps/dbagent/src/app/(main)/projects/[project]/monitoring/page.tsx
+++ b/apps/dbagent/src/app/(main)/projects/[project]/monitoring/page.tsx
@@ -1,13 +1,10 @@
+import { getProjectConnectionList } from '~/app/(main)/projects/[project]/actions';
 import { MonitoringScheduleTable } from '~/components/monitoring/schedules-table';
-import { listConnections } from '~/lib/db/connections';
 
-type PageParams = {
-  project: string;
-};
-
-export default async function Page({ params }: { params: Promise<PageParams> }) {
+export default async function Page({ params }: { params: Promise<{ project: string }> }) {
   const { project } = await params;
-  const connections = await listConnections(project);
+
+  const connections = await getProjectConnectionList(project);
 
   return (
     <div className="container">

--- a/apps/dbagent/src/app/(main)/projects/[project]/monitoring/runs/[schedule]/page.tsx
+++ b/apps/dbagent/src/app/(main)/projects/[project]/monitoring/runs/[schedule]/page.tsx
@@ -1,5 +1,5 @@
+import { getProjectSchedule } from '~/app/(main)/projects/[project]/actions';
 import { ScheduleRunsTable } from '~/components/monitoring/schedule-runs-table';
-import { getSchedule } from '~/lib/db/schedules';
 
 interface PageParams {
   schedule: string;
@@ -7,7 +7,7 @@ interface PageParams {
 
 export default async function Page({ params }: { params: Promise<PageParams> }) {
   const { schedule: scheduleId } = await params;
-  const schedule = await getSchedule(scheduleId);
+  const schedule = await getProjectSchedule(scheduleId);
 
   return (
     <div className="container">

--- a/apps/dbagent/src/app/(main)/projects/[project]/monitoring/schedule/[schedule]/page.tsx
+++ b/apps/dbagent/src/app/(main)/projects/[project]/monitoring/schedule/[schedule]/page.tsx
@@ -1,21 +1,16 @@
+import { getProjectConnectionList } from '~/app/(main)/projects/[project]/actions';
 import { actionListPlaybooks } from '~/components/monitoring/actions';
 import { ScheduleForm } from '~/components/monitoring/schedule-form';
 import { actionListCustomPlaybooksNames } from '~/components/playbooks/action';
-import { listConnections } from '~/lib/db/connections';
 
-type PageParams = {
-  project: string;
-  schedule: string;
-};
-
-export default async function Page({ params }: { params: Promise<PageParams> }) {
+export default async function Page({ params }: { params: Promise<{ project: string; schedule: string }> }) {
   const { project, schedule } = await params;
 
   const builtInPlaybooks = await actionListPlaybooks();
   const customPlaybooks = (await actionListCustomPlaybooksNames(project)) ?? [];
   const playbooks = [...builtInPlaybooks, ...customPlaybooks];
 
-  const connections = await listConnections(project);
+  const connections = await getProjectConnectionList(project);
 
   return (
     <div className="container">

--- a/apps/dbagent/src/app/(main)/projects/[project]/start/cloud/page.tsx
+++ b/apps/dbagent/src/app/(main)/projects/[project]/start/cloud/page.tsx
@@ -1,4 +1,4 @@
-import { getProjectConnectionList, getProject } from '~/app/(main)/projects/[project]/actions';
+import { getProject, getProjectConnectionList } from '~/app/(main)/projects/[project]/actions';
 import { AWSIntegration } from '~/components/aws-integration/aws-integration';
 import { GCPIntegration } from '~/components/gcp-integration/gcp-integration';
 

--- a/apps/dbagent/src/app/(main)/projects/[project]/start/cloud/page.tsx
+++ b/apps/dbagent/src/app/(main)/projects/[project]/start/cloud/page.tsx
@@ -1,7 +1,6 @@
+import { getProjectConnectionList, getProject } from '~/app/(main)/projects/[project]/actions';
 import { AWSIntegration } from '~/components/aws-integration/aws-integration';
 import { GCPIntegration } from '~/components/gcp-integration/gcp-integration';
-import { listConnections } from '~/lib/db/connections';
-import { getProjectById } from '~/lib/db/projects';
 
 type PageParams = {
   project: string;
@@ -9,8 +8,8 @@ type PageParams = {
 
 export default async function Page({ params }: { params: Promise<PageParams> }) {
   const { project: projectId } = await params;
-  const project = await getProjectById(projectId);
-  const connections = await listConnections(projectId);
+  const project = await getProject(projectId);
+  const connections = await getProjectConnectionList(projectId);
 
   return (
     <div className="container mx-auto p-4">

--- a/apps/dbagent/src/app/(main)/projects/[project]/start/collect/page.tsx
+++ b/apps/dbagent/src/app/(main)/projects/[project]/start/collect/page.tsx
@@ -1,13 +1,10 @@
+import { getProjectConnectionList } from '~/app/(main)/projects/[project]/actions';
 import { CollectInfo } from '~/components/collect/collect';
-import { listConnections } from '~/lib/db/connections';
 
-type PageParams = {
-  project: string;
-};
-
-export default async function Page({ params }: { params: Promise<PageParams> }) {
+export default async function Page({ params }: { params: Promise<{ project: string }> }) {
   const { project } = await params;
-  const connections = await listConnections(project);
+
+  const connections = await getProjectConnectionList(project);
 
   return (
     <div className="container mx-auto max-w-6xl p-4">

--- a/apps/dbagent/src/app/(main)/projects/[project]/start/page.tsx
+++ b/apps/dbagent/src/app/(main)/projects/[project]/start/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
-import { Onboarding } from '~/components/onboarding/onboarding';
 import { getProject } from '~/app/(main)/projects/[project]/actions';
+import { Onboarding } from '~/components/onboarding/onboarding';
 
 type PageParams = {
   project: string;

--- a/apps/dbagent/src/app/(main)/projects/[project]/start/page.tsx
+++ b/apps/dbagent/src/app/(main)/projects/[project]/start/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import { Onboarding } from '~/components/onboarding/onboarding';
-import { getProjectById } from '~/lib/db/projects';
+import { getProject } from '~/app/(main)/projects/[project]/actions';
 
 type PageParams = {
   project: string;
@@ -8,7 +8,7 @@ type PageParams = {
 
 export default async function Page({ params }: { params: Promise<PageParams> }) {
   const { project: projectId } = await params;
-  const project = await getProjectById(projectId);
+  const project = await getProject(projectId);
   if (!project) {
     return notFound();
   }

--- a/apps/dbagent/src/app/(main)/projects/actions.ts
+++ b/apps/dbagent/src/app/(main)/projects/actions.ts
@@ -4,6 +4,6 @@ import { getUserSessionDBAccess } from '~/lib/db/db';
 import { listProjects } from '~/lib/db/projects';
 
 export async function getProjectsList() {
-  const db = await getUserSessionDBAccess();
-  return listProjects(db);
+  const dbAccess = await getUserSessionDBAccess();
+  return listProjects(dbAccess);
 }

--- a/apps/dbagent/src/app/(main)/projects/actions.ts
+++ b/apps/dbagent/src/app/(main)/projects/actions.ts
@@ -1,0 +1,9 @@
+'use server';
+
+import { getUserSessionDBAccess } from '~/lib/db/db';
+import { listProjects } from '~/lib/db/projects';
+
+export async function getProjectsList() {
+  const db = await getUserSessionDBAccess();
+  return listProjects(db);
+}

--- a/apps/dbagent/src/app/(main)/projects/page.tsx
+++ b/apps/dbagent/src/app/(main)/projects/page.tsx
@@ -1,8 +1,8 @@
 import { ProjectsList } from '~/components/projects/project-list';
-import { listProjects } from '~/lib/db/projects';
+import { getProjectsList } from './actions';
 
 export default async function ProjectsPage() {
-  const projects = await listProjects();
+  const projects = await getProjectsList();
 
   return <ProjectsList projects={projects} />;
 }

--- a/apps/dbagent/src/app/api/chat/route.ts
+++ b/apps/dbagent/src/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import { streamText } from 'ai';
 import { getChatSystemPrompt, getModelInstance, getTools } from '~/lib/ai/aidba';
 import { getConnection } from '~/lib/db/connections';
 import { getProjectById } from '~/lib/db/projects';
+import { getUserSessionDBAccess } from '~/lib/db/db';
 
 export const runtime = 'nodejs';
 export const maxDuration = 30;
@@ -27,11 +28,12 @@ function errorHandler(error: unknown) {
 export async function POST(req: Request) {
   const { messages, connectionId, model } = await req.json();
 
-  const connection = await getConnection(connectionId);
+  const db = await getUserSessionDBAccess();
+  const connection = await getConnection(db, connectionId);
   if (!connection) {
     return new Response('Connection not found', { status: 404 });
   }
-  const project = await getProjectById(connection.projectId);
+  const project = await getProjectById(db, connection.projectId);
   if (!project) {
     return new Response('Project not found', { status: 404 });
   }

--- a/apps/dbagent/src/app/api/chat/route.ts
+++ b/apps/dbagent/src/app/api/chat/route.ts
@@ -1,8 +1,8 @@
 import { streamText } from 'ai';
 import { getChatSystemPrompt, getModelInstance, getTools } from '~/lib/ai/aidba';
 import { getConnection } from '~/lib/db/connections';
-import { getProjectById } from '~/lib/db/projects';
 import { getUserSessionDBAccess } from '~/lib/db/db';
+import { getProjectById } from '~/lib/db/projects';
 
 export const runtime = 'nodejs';
 export const maxDuration = 30;

--- a/apps/dbagent/src/app/api/chat/route.ts
+++ b/apps/dbagent/src/app/api/chat/route.ts
@@ -29,12 +29,12 @@ function errorHandler(error: unknown) {
 export async function POST(req: Request) {
   const { messages, connectionId, model } = await req.json();
 
-  const db = await getUserSessionDBAccess();
-  const connection = await getConnection(db, connectionId);
+  const dbAccess = await getUserSessionDBAccess();
+  const connection = await getConnection(dbAccess, connectionId);
   if (!connection) {
     return new Response('Connection not found', { status: 404 });
   }
-  const project = await getProjectById(db, connection.projectId);
+  const project = await getProjectById(dbAccess, connection.projectId);
   if (!project) {
     return new Response('Project not found', { status: 404 });
   }

--- a/apps/dbagent/src/components/aws-integration/actions.ts
+++ b/apps/dbagent/src/components/aws-integration/actions.ts
@@ -11,6 +11,7 @@ import {
 } from '~/lib/aws/rds';
 import { associateClusterConnection, saveCluster } from '~/lib/db/aws-clusters';
 import { Connection } from '~/lib/db/connections';
+import { getUserSessionDBAccess } from '~/lib/db/db';
 import { AwsIntegration, getIntegration, saveIntegration } from '~/lib/db/integrations';
 
 export async function fetchRDSClusters(
@@ -40,7 +41,8 @@ export async function fetchRDSClusters(
     }));
     clusters.push(...standaloneAsClusters);
 
-    await saveIntegration(projectId, 'aws', { accessKeyId, secretAccessKey, region });
+    const db = await getUserSessionDBAccess();
+    await saveIntegration(db, projectId, 'aws', { accessKeyId, secretAccessKey, region });
     return { success: true, message: 'RDS instances fetched successfully', data: clusters };
   } catch (error) {
     console.error('Error fetching RDS instances:', error);
@@ -52,7 +54,8 @@ export async function fetchRDSClusterDetails(
   projectId: string,
   clusterInfo: RDSClusterInfo
 ): Promise<{ success: boolean; message: string; data: RDSClusterDetailedInfo | null }> {
-  const aws = await getIntegration(projectId, 'aws');
+  const db = await getUserSessionDBAccess();
+  const aws = await getIntegration(db, projectId, 'aws');
   if (!aws) {
     return { success: false, message: 'AWS integration not found', data: null };
   }
@@ -84,8 +87,9 @@ export async function fetchRDSClusterDetails(
 export async function getAWSIntegration(
   projectId: string
 ): Promise<{ success: boolean; message: string; data: AwsIntegration | null }> {
+  const db = await getUserSessionDBAccess();
   try {
-    const aws = await getIntegration(projectId, 'aws');
+    const aws = await getIntegration(db, projectId, 'aws');
     if (!aws) {
       return { success: false, message: 'AWS integration not found', data: null };
     }
@@ -101,7 +105,8 @@ export async function saveClusterDetails(
   region: string,
   connection: Connection
 ): Promise<{ success: boolean; message: string }> {
-  const aws = await getIntegration(connection.projectId, 'aws');
+  const db = await getUserSessionDBAccess();
+  const aws = await getIntegration(db, connection.projectId, 'aws');
   if (!aws) {
     return { success: false, message: 'AWS integration not found' };
   }
@@ -112,13 +117,13 @@ export async function saveClusterDetails(
   });
   const cluster = await getRDSClusterInfo(clusterIdentifier, client);
   if (cluster) {
-    const instanceId = await saveCluster({
+    const instanceId = await saveCluster(db, {
       projectId: connection.projectId,
       clusterIdentifier,
       region,
       data: cluster
     });
-    await associateClusterConnection({
+    await associateClusterConnection(db, {
       projectId: connection.projectId,
       clusterId: instanceId,
       connectionId: connection.id
@@ -129,7 +134,7 @@ export async function saveClusterDetails(
     if (!instance) {
       return { success: false, message: 'RDS instance not found' };
     }
-    const instanceId = await saveCluster({
+    const instanceId = await saveCluster(db, {
       projectId: connection.projectId,
       clusterIdentifier,
       region,
@@ -147,7 +152,7 @@ export async function saveClusterDetails(
         isStandaloneInstance: true
       }
     });
-    await associateClusterConnection({
+    await associateClusterConnection(db, {
       projectId: connection.projectId,
       clusterId: instanceId,
       connectionId: connection.id

--- a/apps/dbagent/src/components/aws-integration/actions.ts
+++ b/apps/dbagent/src/components/aws-integration/actions.ts
@@ -41,8 +41,8 @@ export async function fetchRDSClusters(
     }));
     clusters.push(...standaloneAsClusters);
 
-    const db = await getUserSessionDBAccess();
-    await saveIntegration(db, projectId, 'aws', { accessKeyId, secretAccessKey, region });
+    const dbAccess = await getUserSessionDBAccess();
+    await saveIntegration(dbAccess, projectId, 'aws', { accessKeyId, secretAccessKey, region });
     return { success: true, message: 'RDS instances fetched successfully', data: clusters };
   } catch (error) {
     console.error('Error fetching RDS instances:', error);
@@ -54,8 +54,8 @@ export async function fetchRDSClusterDetails(
   projectId: string,
   clusterInfo: RDSClusterInfo
 ): Promise<{ success: boolean; message: string; data: RDSClusterDetailedInfo | null }> {
-  const db = await getUserSessionDBAccess();
-  const aws = await getIntegration(db, projectId, 'aws');
+  const dbAccess = await getUserSessionDBAccess();
+  const aws = await getIntegration(dbAccess, projectId, 'aws');
   if (!aws) {
     return { success: false, message: 'AWS integration not found', data: null };
   }
@@ -87,9 +87,9 @@ export async function fetchRDSClusterDetails(
 export async function getAWSIntegration(
   projectId: string
 ): Promise<{ success: boolean; message: string; data: AwsIntegration | null }> {
-  const db = await getUserSessionDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   try {
-    const aws = await getIntegration(db, projectId, 'aws');
+    const aws = await getIntegration(dbAccess, projectId, 'aws');
     if (!aws) {
       return { success: false, message: 'AWS integration not found', data: null };
     }
@@ -105,8 +105,8 @@ export async function saveClusterDetails(
   region: string,
   connection: Connection
 ): Promise<{ success: boolean; message: string }> {
-  const db = await getUserSessionDBAccess();
-  const aws = await getIntegration(db, connection.projectId, 'aws');
+  const dbAccess = await getUserSessionDBAccess();
+  const aws = await getIntegration(dbAccess, connection.projectId, 'aws');
   if (!aws) {
     return { success: false, message: 'AWS integration not found' };
   }
@@ -117,13 +117,13 @@ export async function saveClusterDetails(
   });
   const cluster = await getRDSClusterInfo(clusterIdentifier, client);
   if (cluster) {
-    const instanceId = await saveCluster(db, {
+    const instanceId = await saveCluster(dbAccess, {
       projectId: connection.projectId,
       clusterIdentifier,
       region,
       data: cluster
     });
-    await associateClusterConnection(db, {
+    await associateClusterConnection(dbAccess, {
       projectId: connection.projectId,
       clusterId: instanceId,
       connectionId: connection.id
@@ -134,7 +134,7 @@ export async function saveClusterDetails(
     if (!instance) {
       return { success: false, message: 'RDS instance not found' };
     }
-    const instanceId = await saveCluster(db, {
+    const instanceId = await saveCluster(dbAccess, {
       projectId: connection.projectId,
       clusterIdentifier,
       region,
@@ -152,7 +152,7 @@ export async function saveClusterDetails(
         isStandaloneInstance: true
       }
     });
-    await associateClusterConnection(db, {
+    await associateClusterConnection(dbAccess, {
       projectId: connection.projectId,
       clusterId: instanceId,
       connectionId: connection.id

--- a/apps/dbagent/src/components/chats/actions.ts
+++ b/apps/dbagent/src/components/chats/actions.ts
@@ -7,10 +7,10 @@ import { getSchedule } from '~/lib/db/schedules';
 export async function actionGetScheduleRun(runId?: string) {
   if (!runId) return null;
 
-  const db = await getUserSessionDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   try {
-    const run = await getScheduleRun(db, runId);
-    const schedule = await getSchedule(db, run.scheduleId);
+    const run = await getScheduleRun(dbAccess, runId);
+    const schedule = await getSchedule(dbAccess, run.scheduleId);
     return { schedule, run };
   } catch (error) {
     return null;

--- a/apps/dbagent/src/components/chats/actions.ts
+++ b/apps/dbagent/src/components/chats/actions.ts
@@ -1,14 +1,16 @@
 'use server';
 
+import { getUserSessionDBAccess } from '~/lib/db/db';
 import { getScheduleRun } from '~/lib/db/schedule-runs';
 import { getSchedule } from '~/lib/db/schedules';
 
 export async function actionGetScheduleRun(runId?: string) {
   if (!runId) return null;
 
+  const db = await getUserSessionDBAccess();
   try {
-    const run = await getScheduleRun(runId);
-    const schedule = await getSchedule(run.scheduleId);
+    const run = await getScheduleRun(db, runId);
+    const schedule = await getSchedule(db, run.scheduleId);
     return { schedule, run };
   } catch (error) {
     return null;

--- a/apps/dbagent/src/components/collect/actions.ts
+++ b/apps/dbagent/src/components/collect/actions.ts
@@ -2,6 +2,7 @@
 
 import { getConnectionInfo, saveConnectionInfo } from '~/lib/db/connection-info';
 import { Connection } from '~/lib/db/connections';
+import { getUserDBAccess, getUserSessionDBAccess } from '~/lib/db/db';
 import {
   getExtensions,
   getPerformanceSettings,
@@ -39,8 +40,14 @@ export async function collectTables(
   } catch (error) {
     return { success: false, message: `Error collecting tables: ${error}`, data: [] };
   }
+  const db = await getUserSessionDBAccess();
   try {
-    await saveConnectionInfo({ projectId: connection.projectId, connectionId: connection.id, type: 'tables', data });
+    await saveConnectionInfo(db, {
+      projectId: connection.projectId,
+      connectionId: connection.id,
+      type: 'tables',
+      data
+    });
   } catch (error) {
     return { success: false, message: `Error saving tables: ${error}`, data: [] };
   }
@@ -63,8 +70,9 @@ export async function collectExtensions(
   } catch (error) {
     return { success: false, message: `Error collecting extensions: ${error}`, data: [] };
   }
+  const db = await getUserSessionDBAccess();
   try {
-    await saveConnectionInfo({
+    await saveConnectionInfo(db, {
       projectId: connection.projectId,
       connectionId: connection.id,
       type: 'extensions',
@@ -88,8 +96,9 @@ export async function collectPerformanceSettings(
   } catch (error) {
     return { success: false, message: `Error collecting performance settings: ${error}`, data: [] };
   }
+  const db = await getUserSessionDBAccess();
   try {
-    await saveConnectionInfo({
+    await saveConnectionInfo(db, {
       projectId: connection.projectId,
       connectionId: connection.id,
       type: 'performance_settings',
@@ -113,8 +122,9 @@ export async function collectVacuumData(
   } catch (error) {
     return { success: false, message: `Error collecting vacuum data: ${error}`, data: [] };
   }
+  const db = await getUserSessionDBAccess();
   try {
-    await saveConnectionInfo({
+    await saveConnectionInfo(db, {
       projectId: connection.projectId,
       connectionId: connection.id,
       type: 'vacuum_settings',
@@ -139,11 +149,13 @@ export async function getCollectInfo(
   if (!connection) {
     return { success: false, message: 'No connection selected', data: null };
   }
+
+  const db = await getUserDBAccess();
   try {
-    const tables = await getConnectionInfo(connection.id, 'tables');
-    const extensions = await getConnectionInfo(connection.id, 'extensions');
-    const performance_settings = await getConnectionInfo(connection.id, 'performance_settings');
-    const vacuum_settings = await getConnectionInfo(connection.id, 'vacuum_settings');
+    const tables = await getConnectionInfo(db, connection.id, 'tables');
+    const extensions = await getConnectionInfo(db, connection.id, 'extensions');
+    const performance_settings = await getConnectionInfo(db, connection.id, 'performance_settings');
+    const vacuum_settings = await getConnectionInfo(db, connection.id, 'vacuum_settings');
     if (!tables || !extensions || !performance_settings || !vacuum_settings) {
       return { success: true, message: 'No data found', data: null };
     }

--- a/apps/dbagent/src/components/collect/actions.ts
+++ b/apps/dbagent/src/components/collect/actions.ts
@@ -2,7 +2,7 @@
 
 import { getConnectionInfo, saveConnectionInfo } from '~/lib/db/connection-info';
 import { Connection } from '~/lib/db/connections';
-import { getUserDBAccess, getUserSessionDBAccess } from '~/lib/db/db';
+import { getUserSessionDBAccess } from '~/lib/db/db';
 import {
   getExtensions,
   getPerformanceSettings,
@@ -40,9 +40,9 @@ export async function collectTables(
   } catch (error) {
     return { success: false, message: `Error collecting tables: ${error}`, data: [] };
   }
-  const db = await getUserSessionDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   try {
-    await saveConnectionInfo(db, {
+    await saveConnectionInfo(dbAccess, {
       projectId: connection.projectId,
       connectionId: connection.id,
       type: 'tables',
@@ -70,9 +70,9 @@ export async function collectExtensions(
   } catch (error) {
     return { success: false, message: `Error collecting extensions: ${error}`, data: [] };
   }
-  const db = await getUserSessionDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   try {
-    await saveConnectionInfo(db, {
+    await saveConnectionInfo(dbAccess, {
       projectId: connection.projectId,
       connectionId: connection.id,
       type: 'extensions',
@@ -96,9 +96,9 @@ export async function collectPerformanceSettings(
   } catch (error) {
     return { success: false, message: `Error collecting performance settings: ${error}`, data: [] };
   }
-  const db = await getUserSessionDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   try {
-    await saveConnectionInfo(db, {
+    await saveConnectionInfo(dbAccess, {
       projectId: connection.projectId,
       connectionId: connection.id,
       type: 'performance_settings',
@@ -122,9 +122,9 @@ export async function collectVacuumData(
   } catch (error) {
     return { success: false, message: `Error collecting vacuum data: ${error}`, data: [] };
   }
-  const db = await getUserSessionDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   try {
-    await saveConnectionInfo(db, {
+    await saveConnectionInfo(dbAccess, {
       projectId: connection.projectId,
       connectionId: connection.id,
       type: 'vacuum_settings',
@@ -150,12 +150,12 @@ export async function getCollectInfo(
     return { success: false, message: 'No connection selected', data: null };
   }
 
-  const db = await getUserDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   try {
-    const tables = await getConnectionInfo(db, connection.id, 'tables');
-    const extensions = await getConnectionInfo(db, connection.id, 'extensions');
-    const performance_settings = await getConnectionInfo(db, connection.id, 'performance_settings');
-    const vacuum_settings = await getConnectionInfo(db, connection.id, 'vacuum_settings');
+    const tables = await getConnectionInfo(dbAccess, connection.id, 'tables');
+    const extensions = await getConnectionInfo(dbAccess, connection.id, 'extensions');
+    const performance_settings = await getConnectionInfo(dbAccess, connection.id, 'performance_settings');
+    const vacuum_settings = await getConnectionInfo(dbAccess, connection.id, 'vacuum_settings');
     if (!tables || !extensions || !performance_settings || !vacuum_settings) {
       return { success: true, message: 'No data found', data: null };
     }

--- a/apps/dbagent/src/components/connections/actions.ts
+++ b/apps/dbagent/src/components/connections/actions.ts
@@ -23,18 +23,18 @@ function translateError(error: string) {
 }
 
 export async function actionGetConnection(id: string) {
-  const db = await getUserSessionDBAccess();
-  return getConnection(db, id);
+  const dbAccess = await getUserSessionDBAccess();
+  return getConnection(dbAccess, id);
 }
 
 export async function actionDeleteConnection(id: string) {
-  const db = await getUserSessionDBAccess();
-  return deleteConnection(db, id);
+  const dbAccess = await getUserSessionDBAccess();
+  return deleteConnection(dbAccess, id);
 }
 
 export async function actionListConnections(projectId: string) {
-  const db = await getUserSessionDBAccess();
-  return listConnections(db, projectId);
+  const dbAccess = await getUserSessionDBAccess();
+  return listConnections(dbAccess, projectId);
 }
 
 export async function actionSaveConnection({
@@ -48,7 +48,7 @@ export async function actionSaveConnection({
   name: string;
   connectionString: string;
 }) {
-  const db = await getUserSessionDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
 
   try {
     const validateResult = await validateConnection(connectionString);
@@ -57,10 +57,10 @@ export async function actionSaveConnection({
     }
 
     if (id) {
-      await updateConnection(db, { id, name, connectionString });
+      await updateConnection(dbAccess, { id, name, connectionString });
       return { success: true, message: 'Connection updated successfully' };
     } else {
-      await addConnection(db, { projectId, name, connectionString });
+      await addConnection(dbAccess, { projectId, name, connectionString });
       return { success: true, message: 'Connection added successfully' };
     }
   } catch (error) {
@@ -70,9 +70,9 @@ export async function actionSaveConnection({
 }
 
 export async function actionMakeConnectionDefault(id: string) {
-  const db = await getUserSessionDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   try {
-    const result = await makeConnectionDefault(db, id);
+    const result = await makeConnectionDefault(dbAccess, id);
     revalidatePath('/connections');
     return result;
   } catch (error) {

--- a/apps/dbagent/src/components/connections/actions.ts
+++ b/apps/dbagent/src/components/connections/actions.ts
@@ -1,7 +1,15 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { addConnection, makeConnectionDefault, updateConnection } from '~/lib/db/connections';
+import {
+  addConnection,
+  deleteConnection,
+  getConnection,
+  listConnections,
+  makeConnectionDefault,
+  updateConnection
+} from '~/lib/db/connections';
+import { getUserSessionDBAccess } from '~/lib/db/db';
 import { getTargetDbConnection } from '~/lib/targetdb/db';
 
 function translateError(error: string) {
@@ -12,6 +20,21 @@ function translateError(error: string) {
     return 'A connection with this name already exists.';
   }
   return error;
+}
+
+export async function actionGetConnection(id: string) {
+  const db = await getUserSessionDBAccess();
+  return getConnection(db, id);
+}
+
+export async function actionDeleteConnection(id: string) {
+  const db = await getUserSessionDBAccess();
+  return deleteConnection(db, id);
+}
+
+export async function actionListConnections(projectId: string) {
+  const db = await getUserSessionDBAccess();
+  return listConnections(db, projectId);
 }
 
 export async function actionSaveConnection({
@@ -25,6 +48,8 @@ export async function actionSaveConnection({
   name: string;
   connectionString: string;
 }) {
+  const db = await getUserSessionDBAccess();
+
   try {
     const validateResult = await validateConnection(connectionString);
     if (!validateResult.success) {
@@ -32,10 +57,10 @@ export async function actionSaveConnection({
     }
 
     if (id) {
-      await updateConnection({ id, name, connectionString });
+      await updateConnection(db, { id, name, connectionString });
       return { success: true, message: 'Connection updated successfully' };
     } else {
-      await addConnection({ projectId, name, connectionString });
+      await addConnection(db, { projectId, name, connectionString });
       return { success: true, message: 'Connection added successfully' };
     }
   } catch (error) {
@@ -45,8 +70,9 @@ export async function actionSaveConnection({
 }
 
 export async function actionMakeConnectionDefault(id: string) {
+  const db = await getUserSessionDBAccess();
   try {
-    const result = await makeConnectionDefault(id);
+    const result = await makeConnectionDefault(db, id);
     revalidatePath('/connections');
     return result;
   } catch (error) {

--- a/apps/dbagent/src/components/connections/connection-form.tsx
+++ b/apps/dbagent/src/components/connections/connection-form.tsx
@@ -3,8 +3,7 @@
 import { Button, Input, Label, toast, useForm } from '@internal/components';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { deleteConnection, getConnection } from '~/lib/db/connections';
-import { actionSaveConnection, validateConnection } from './actions';
+import { actionDeleteConnection, actionGetConnection, actionSaveConnection, validateConnection } from './actions';
 
 type FormData = {
   name: string;
@@ -36,7 +35,7 @@ export function ConnectionForm({ projectId, id }: ConnectionFormProps) {
   useEffect(() => {
     async function initializeForm() {
       if (id) {
-        const connection = await getConnection(id);
+        const connection = await actionGetConnection(id);
         if (connection) {
           reset({
             name: connection.name,
@@ -83,7 +82,7 @@ export function ConnectionForm({ projectId, id }: ConnectionFormProps) {
   const handleDelete = async () => {
     if (!id) return;
     try {
-      await deleteConnection(id);
+      await actionDeleteConnection(id);
       toast('Connection deleted successfully');
       router.push(`/projects/${projectId}/start/connect`);
     } catch (error) {

--- a/apps/dbagent/src/components/connections/connections-list.tsx
+++ b/apps/dbagent/src/components/connections/connections-list.tsx
@@ -5,8 +5,8 @@ import { CheckIcon } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { Connection, listConnections } from '~/lib/db/connections';
-import { actionMakeConnectionDefault } from './actions';
+import { Connection } from '~/lib/db/connections';
+import { actionListConnections, actionMakeConnectionDefault } from './actions';
 
 function maskConnectionString(connString: string): string {
   // Handle URL format for both postgresql:// and postgres:// prefixes
@@ -23,7 +23,7 @@ export function ConnectionsList() {
 
   useEffect(() => {
     const loadConnections = async () => {
-      const connections = await listConnections(project);
+      const connections = await actionListConnections(project);
       if (connections.length === 0) {
         router.push(`/projects/${project}/start/connect/add`);
         return;

--- a/apps/dbagent/src/components/monitoring/actions.ts
+++ b/apps/dbagent/src/components/monitoring/actions.ts
@@ -36,20 +36,20 @@ export async function actionCreateSchedule(schedule: Omit<Schedule, 'id' | 'user
     schedule.status = 'scheduled';
     schedule.nextRun = scheduleGetNextRun({ ...schedule, userId }, new Date()).toISOString();
   }
-  const db = await getUserSessionDBAccess();
-  return insertSchedule(db, { ...schedule, userId });
+  const dbAccess = await getUserSessionDBAccess();
+  return insertSchedule(dbAccess, { ...schedule, userId });
 }
 
 export async function actionUpdateSchedule(schedule: Omit<Schedule, 'userId'>): Promise<Schedule> {
   const session = await auth();
   const userId = session?.user?.id ?? '';
-  const db = await getUserDBAccess(userId);
-  return updateSchedule(db, { ...schedule, userId });
+  const dbAccess = await getUserDBAccess(userId);
+  return updateSchedule(dbAccess, { ...schedule, userId });
 }
 
 export async function actionGetSchedules(): Promise<Schedule[]> {
-  const db = await getUserSessionDBAccess();
-  const schedules = await getSchedules(db);
+  const dbAccess = await getUserSessionDBAccess();
+  const schedules = await getSchedules(dbAccess);
   // Ensure last_run is serialized as string
   schedules.forEach((schedule) => {
     if (schedule.lastRun) {
@@ -63,13 +63,13 @@ export async function actionGetSchedules(): Promise<Schedule[]> {
 }
 
 export async function actionGetSchedule(id: string): Promise<Schedule> {
-  const db = await getUserSessionDBAccess();
-  return getSchedule(db, id);
+  const dbAccess = await getUserSessionDBAccess();
+  return getSchedule(dbAccess, id);
 }
 
 export async function actionDeleteSchedule(id: string): Promise<void> {
-  const db = await getUserSessionDBAccess();
-  return deleteSchedule(db, id);
+  const dbAccess = await getUserSessionDBAccess();
+  return deleteSchedule(dbAccess, id);
 }
 
 export async function actionListPlaybooks(): Promise<string[]> {
@@ -77,24 +77,24 @@ export async function actionListPlaybooks(): Promise<string[]> {
 }
 
 export async function actionUpdateScheduleEnabled(scheduleId: string, enabled: boolean) {
-  const db = await getUserSessionDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   if (enabled) {
-    const schedule = await getSchedule(db, scheduleId);
+    const schedule = await getSchedule(dbAccess, scheduleId);
     schedule.enabled = true;
     schedule.status = 'scheduled';
     schedule.nextRun = scheduleGetNextRun(schedule, new Date()).toUTCString();
     console.log('nextRun', schedule.nextRun);
-    await updateScheduleRunData(db, schedule);
+    await updateScheduleRunData(dbAccess, schedule);
   } else {
-    const schedule = await getSchedule(db, scheduleId);
+    const schedule = await getSchedule(dbAccess, scheduleId);
     schedule.enabled = false;
     schedule.status = 'disabled';
     schedule.nextRun = undefined;
-    await updateScheduleRunData(db, schedule);
+    await updateScheduleRunData(dbAccess, schedule);
   }
 }
 
 export async function actionGetScheduleRuns(scheduleId: string): Promise<ScheduleRun[]> {
-  const db = await getUserSessionDBAccess();
-  return getScheduleRuns(db, scheduleId);
+  const dbAccess = await getUserSessionDBAccess();
+  return getScheduleRuns(dbAccess, scheduleId);
 }

--- a/apps/dbagent/src/components/monitoring/actions.ts
+++ b/apps/dbagent/src/components/monitoring/actions.ts
@@ -3,6 +3,7 @@
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 import { auth } from '~/auth';
+import { getUserDBAccess, getUserSessionDBAccess } from '~/lib/db/db';
 import { getScheduleRuns, ScheduleRun } from '~/lib/db/schedule-runs';
 import {
   deleteSchedule,
@@ -35,17 +36,20 @@ export async function actionCreateSchedule(schedule: Omit<Schedule, 'id' | 'user
     schedule.status = 'scheduled';
     schedule.nextRun = scheduleGetNextRun({ ...schedule, userId }, new Date()).toISOString();
   }
-  return insertSchedule({ ...schedule, userId });
+  const db = await getUserSessionDBAccess();
+  return insertSchedule(db, { ...schedule, userId });
 }
 
 export async function actionUpdateSchedule(schedule: Omit<Schedule, 'userId'>): Promise<Schedule> {
   const session = await auth();
   const userId = session?.user?.id ?? '';
-  return updateSchedule({ ...schedule, userId });
+  const db = await getUserDBAccess(userId);
+  return updateSchedule(db, { ...schedule, userId });
 }
 
 export async function actionGetSchedules(): Promise<Schedule[]> {
-  const schedules = await getSchedules();
+  const db = await getUserSessionDBAccess();
+  const schedules = await getSchedules(db);
   // Ensure last_run is serialized as string
   schedules.forEach((schedule) => {
     if (schedule.lastRun) {
@@ -59,11 +63,13 @@ export async function actionGetSchedules(): Promise<Schedule[]> {
 }
 
 export async function actionGetSchedule(id: string): Promise<Schedule> {
-  return getSchedule(id);
+  const db = await getUserSessionDBAccess();
+  return getSchedule(db, id);
 }
 
 export async function actionDeleteSchedule(id: string): Promise<void> {
-  return deleteSchedule(id);
+  const db = await getUserSessionDBAccess();
+  return deleteSchedule(db, id);
 }
 
 export async function actionListPlaybooks(): Promise<string[]> {
@@ -71,22 +77,24 @@ export async function actionListPlaybooks(): Promise<string[]> {
 }
 
 export async function actionUpdateScheduleEnabled(scheduleId: string, enabled: boolean) {
+  const db = await getUserSessionDBAccess();
   if (enabled) {
-    const schedule = await getSchedule(scheduleId);
+    const schedule = await getSchedule(db, scheduleId);
     schedule.enabled = true;
     schedule.status = 'scheduled';
     schedule.nextRun = scheduleGetNextRun(schedule, new Date()).toUTCString();
     console.log('nextRun', schedule.nextRun);
-    await updateScheduleRunData(schedule);
+    await updateScheduleRunData(db, schedule);
   } else {
-    const schedule = await getSchedule(scheduleId);
+    const schedule = await getSchedule(db, scheduleId);
     schedule.enabled = false;
     schedule.status = 'disabled';
     schedule.nextRun = undefined;
-    await updateScheduleRunData(schedule);
+    await updateScheduleRunData(db, schedule);
   }
 }
 
 export async function actionGetScheduleRuns(scheduleId: string): Promise<ScheduleRun[]> {
-  return getScheduleRuns(scheduleId);
+  const db = await getUserSessionDBAccess();
+  return getScheduleRuns(db, scheduleId);
 }

--- a/apps/dbagent/src/components/onboarding/actions.ts
+++ b/apps/dbagent/src/components/onboarding/actions.ts
@@ -3,8 +3,8 @@
 import { getClusters } from '~/lib/db/aws-clusters';
 import { getConnectionInfo } from '~/lib/db/connection-info';
 import { getDefaultConnection } from '~/lib/db/connections';
-import { getInstances } from '~/lib/db/gcp-instances';
 import { getUserSessionDBAccess } from '~/lib/db/db';
+import { getInstances } from '~/lib/db/gcp-instances';
 import { getIntegration } from '~/lib/db/integrations';
 import { getProjectById } from '~/lib/db/projects';
 

--- a/apps/dbagent/src/components/onboarding/actions.ts
+++ b/apps/dbagent/src/components/onboarding/actions.ts
@@ -4,37 +4,40 @@ import { getClusters } from '~/lib/db/aws-clusters';
 import { getConnectionInfo } from '~/lib/db/connection-info';
 import { getDefaultConnection } from '~/lib/db/connections';
 import { getInstances } from '~/lib/db/gcp-instances';
+import { getUserSessionDBAccess } from '~/lib/db/db';
 import { getIntegration } from '~/lib/db/integrations';
 import { getProjectById } from '~/lib/db/projects';
 
 // Server action to get completed tasks
 export async function getCompletedTasks(projectId: string): Promise<string[]> {
+  const dbAccess = await getUserSessionDBAccess();
+
   const completedTasks: string[] = [];
-  const connection = await getDefaultConnection(projectId);
+  const connection = await getDefaultConnection(dbAccess, projectId);
   if (!connection) {
     return [];
   }
   completedTasks.push('connect');
 
-  const tables = await getConnectionInfo(connection.id, 'tables');
+  const tables = await getConnectionInfo(dbAccess, connection.id, 'tables');
   if (tables) {
     completedTasks.push('collect');
   }
 
-  const project = await getProjectById(projectId);
+  const project = await getProjectById(dbAccess, projectId);
   if (project?.cloudProvider === 'aws') {
-    const clusters = await getClusters(projectId);
+    const clusters = await getClusters(dbAccess, projectId);
     if (clusters.length > 0) {
       completedTasks.push('cloud');
     }
   } else if (project?.cloudProvider === 'gcp') {
-    const instances = await getInstances(projectId);
+    const instances = await getInstances(dbAccess, projectId);
     if (instances.length > 0) {
       completedTasks.push('cloud');
     }
   }
 
-  const slack = await getIntegration(projectId, 'slack');
+  const slack = await getIntegration(dbAccess, projectId, 'slack');
   if (slack) {
     completedTasks.push('notifications');
   }

--- a/apps/dbagent/src/components/playbooks/action.ts
+++ b/apps/dbagent/src/components/playbooks/action.ts
@@ -5,7 +5,7 @@ import { generateText } from 'ai';
 import { auth } from '~/auth';
 
 import { dbCreatePlaybook, dbDeletePlaybook, dbUpdatePlaybook } from '~/lib/db/custom-playbooks';
-import { getUserDBAccess } from '~/lib/db/db';
+import { getUserDBAccess, getUserSessionDBAccess } from '~/lib/db/db';
 import { getSchedulesByUserIdAndProjectId, Schedule } from '~/lib/db/schedules';
 import {
   customPlaybook,
@@ -84,7 +84,7 @@ export async function actionCreatePlaybook(input: customPlaybook): Promise<Playb
   const session = await auth();
   const userId = session?.user?.id ?? '';
   console.log('Creating playbook {input: ', input, '}');
-  const dbAccess = await getUserDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   return await dbCreatePlaybook(dbAccess, { ...input, createdBy: userId });
 }
 
@@ -94,14 +94,14 @@ export async function actionUpdatePlaybook(
   input: { description?: string; content?: string }
 ): Promise<Playbook | null> {
   console.log('Updating playbook {id: ', id, '} with {input: ', input, '}');
-  const dbAccess = await getUserDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   return await dbUpdatePlaybook(dbAccess, id, input);
 }
 
 //playbook db delete
 export async function actionDeletePlaybook(id: string): Promise<void> {
   console.log('Deleting playbook {id: ', id, '}');
-  const dbAccess = await getUserDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   return await dbDeletePlaybook(dbAccess, id);
 }
 

--- a/apps/dbagent/src/components/playbooks/custom-playbook-form.tsx
+++ b/apps/dbagent/src/components/playbooks/custom-playbook-form.tsx
@@ -5,13 +5,13 @@ import { ArrowLeft, TrashIcon, Wand2 } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { getSchedulesByUserIdAndProjectId } from '~/lib/db/schedules';
 import { Playbook } from '~/lib/tools/playbooks';
 import {
   actionCreatePlaybook,
   actionDeletePlaybook,
   actionGeneratePlaybookContent,
   actionGetCustomPlaybook,
+  actionGetSchedulesByUserIdAndProjectId,
   actionUpdatePlaybook
 } from './action';
 
@@ -73,7 +73,7 @@ export function CustomPlaybookForm({ initialData, isEditing = false }: CustomPla
       //if it does, do not delete the playbook
       //if it does not, delete the playbook
       const playbookToDelete = await actionGetCustomPlaybook(project, initialData.id);
-      const schedules = await getSchedulesByUserIdAndProjectId(playbookToDelete.createdBy, project);
+      const schedules = await actionGetSchedulesByUserIdAndProjectId(playbookToDelete.createdBy, project);
       const doesScheduleExistForCustomPlaybook = schedules.find(
         (schedule) => schedule.playbook === playbookToDelete.name
       );

--- a/apps/dbagent/src/components/playbooks/playbook-view.tsx
+++ b/apps/dbagent/src/components/playbooks/playbook-view.tsx
@@ -22,9 +22,7 @@ export function PlaybookView({ playbook }: { playbook: Playbook }) {
       <Card>
         <CardHeader>
           <CardTitle>Playbook:{playbook.name}</CardTitle>
-          <CardDescription>
-            <p className="text-muted-foreground">{playbook.description}</p>
-          </CardDescription>
+          <CardDescription>{playbook.description}</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="bg-muted prose prose-sm whitespace-pre-wrap rounded-md p-4">{playbook.content}</div>

--- a/apps/dbagent/src/components/projects/actions.ts
+++ b/apps/dbagent/src/components/projects/actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { getUserSessionDBAccess } from '~/lib/db/db';
-import { createProject, deleteProject, Project, updateProject } from '~/lib/db/projects';
-import { CloudProviderType } from '~/lib/db/projects';
+import { CloudProviderType, createProject, deleteProject, Project, updateProject } from '~/lib/db/projects';
 
 export async function actionCreateProject(name: string, cloudProvider: CloudProviderType) {
   const db = await getUserSessionDBAccess();

--- a/apps/dbagent/src/components/projects/actions.ts
+++ b/apps/dbagent/src/components/projects/actions.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import { getUserSessionDBAccess } from '~/lib/db/db';
+import { createProject, deleteProject, Project, updateProject } from '~/lib/db/projects';
+import { CloudProviderType } from '~/lib/db/projects';
+
+export async function actionCreateProject(name: string, cloudProvider: CloudProviderType) {
+  const db = await getUserSessionDBAccess();
+  return createProject(db, { name, cloudProvider });
+}
+
+export async function actionDeleteProject(id: string) {
+  const db = await getUserSessionDBAccess();
+  return deleteProject(db, { id });
+}
+
+export async function actionUpdateProject(id: string, update: Partial<Omit<Project, 'id'>>) {
+  const db = await getUserSessionDBAccess();
+  return updateProject(db, id, update);
+}

--- a/apps/dbagent/src/components/projects/actions.ts
+++ b/apps/dbagent/src/components/projects/actions.ts
@@ -4,16 +4,16 @@ import { getUserSessionDBAccess } from '~/lib/db/db';
 import { CloudProviderType, createProject, deleteProject, Project, updateProject } from '~/lib/db/projects';
 
 export async function actionCreateProject(name: string, cloudProvider: CloudProviderType) {
-  const db = await getUserSessionDBAccess();
-  return createProject(db, { name, cloudProvider });
+  const dbAccess = await getUserSessionDBAccess();
+  return createProject(dbAccess, { name, cloudProvider });
 }
 
 export async function actionDeleteProject(id: string) {
-  const db = await getUserSessionDBAccess();
-  return deleteProject(db, { id });
+  const dbAccess = await getUserSessionDBAccess();
+  return deleteProject(dbAccess, { id });
 }
 
 export async function actionUpdateProject(id: string, update: Partial<Omit<Project, 'id'>>) {
-  const db = await getUserSessionDBAccess();
-  return updateProject(db, id, update);
+  const dbAccess = await getUserSessionDBAccess();
+  return updateProject(dbAccess, id, update);
 }

--- a/apps/dbagent/src/components/projects/project-list.tsx
+++ b/apps/dbagent/src/components/projects/project-list.tsx
@@ -33,7 +33,8 @@ import {
 import { Database, MoreVertical, PlusCircle } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Suspense, useState } from 'react';
-import { CloudProviderType, createProject, deleteProject, Project, updateProject } from '~/lib/db/projects';
+import { CloudProviderType, Project } from '~/lib/db/projects';
+import { actionCreateProject, actionDeleteProject, actionUpdateProject } from './actions';
 
 interface ProjectListProps {
   projects: Project[];
@@ -60,10 +61,7 @@ function CreateProjectButton() {
     setIsLoading(true);
 
     try {
-      const projectId = await createProject({
-        name: projectName,
-        cloudProvider
-      });
+      const projectId = await actionCreateProject(projectName, cloudProvider);
       router.push(`/projects/${projectId}/start`);
     } catch (error: any) {
       toast.error(error.message);
@@ -190,7 +188,7 @@ function ProjectCard({ project }: { project: Project }) {
   const handleRename = async () => {
     if (newProjectName.trim() !== '') {
       try {
-        await updateProject(project.id, { name: newProjectName });
+        await actionUpdateProject(project.id, { name: newProjectName });
         toast.success('Project renamed successfully');
         router.refresh();
       } catch (error: any) {
@@ -202,7 +200,7 @@ function ProjectCard({ project }: { project: Project }) {
 
   const handleDelete = async () => {
     try {
-      await deleteProject({ id: project.id });
+      await actionDeleteProject(project.id);
       toast.success('Project deleted successfully');
       router.refresh();
     } catch (error: any) {
@@ -311,10 +309,7 @@ function CreateProjectOnboarding() {
     setIsLoading(true);
 
     try {
-      const projectId = await createProject({
-        name: projectName,
-        cloudProvider
-      });
+      const projectId = await actionCreateProject(projectName, cloudProvider);
       router.push(`/projects/${projectId}/start`);
     } catch (error: any) {
       toast.error(error.message);

--- a/apps/dbagent/src/components/slack-integration/actions.ts
+++ b/apps/dbagent/src/components/slack-integration/actions.ts
@@ -4,8 +4,8 @@ import { getUserSessionDBAccess } from '~/lib/db/db';
 import { getIntegration, saveIntegration } from '~/lib/db/integrations';
 
 export async function actionGetWebhookUrl(projectId: string) {
-  const db = await getUserSessionDBAccess();
-  return getIntegration(db, projectId, 'slack');
+  const dbAccess = await getUserSessionDBAccess();
+  return getIntegration(dbAccess, projectId, 'slack');
 }
 
 export async function actionSaveWebhookUrl(
@@ -21,9 +21,9 @@ export async function actionSaveWebhookUrl(
     return { success: false, message: 'Invalid webhook URL' };
   }
 
-  const db = await getUserSessionDBAccess();
+  const dbAccess = await getUserSessionDBAccess();
   try {
-    await saveIntegration(db, projectId, 'slack', { webhookUrl });
+    await saveIntegration(dbAccess, projectId, 'slack', { webhookUrl });
   } catch (error) {
     console.error('Failed to save webhook URL:', error);
     return { success: false, message: `Failed to save webhook URL.` };

--- a/apps/dbagent/src/components/slack-integration/actions.ts
+++ b/apps/dbagent/src/components/slack-integration/actions.ts
@@ -1,8 +1,14 @@
 'use server';
 
-import { saveIntegration } from '~/lib/db/integrations';
+import { getUserSessionDBAccess } from '~/lib/db/db';
+import { getIntegration, saveIntegration } from '~/lib/db/integrations';
 
-export async function saveWebhookUrl(
+export async function actionGetWebhookUrl(projectId: string) {
+  const db = await getUserSessionDBAccess();
+  return getIntegration(db, projectId, 'slack');
+}
+
+export async function actionSaveWebhookUrl(
   projectId: string,
   webhookUrl: string
 ): Promise<{ success: boolean; message: string }> {
@@ -15,8 +21,9 @@ export async function saveWebhookUrl(
     return { success: false, message: 'Invalid webhook URL' };
   }
 
+  const db = await getUserSessionDBAccess();
   try {
-    await saveIntegration(projectId, 'slack', { webhookUrl });
+    await saveIntegration(db, projectId, 'slack', { webhookUrl });
   } catch (error) {
     console.error('Failed to save webhook URL:', error);
     return { success: false, message: `Failed to save webhook URL.` };

--- a/apps/dbagent/src/components/slack-integration/slack-integration.tsx
+++ b/apps/dbagent/src/components/slack-integration/slack-integration.tsx
@@ -18,8 +18,7 @@ import {
 import { AlertCircle } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import { getIntegration } from '~/lib/db/integrations';
-import { saveWebhookUrl } from './actions';
+import { actionGetWebhookUrl, actionSaveWebhookUrl } from './actions';
 
 export function SlackIntegration({ projectId }: { projectId: string }) {
   const [isLoading, setIsLoading] = useState(true);
@@ -38,7 +37,7 @@ export function SlackIntegration({ projectId }: { projectId: string }) {
   useEffect(() => {
     const fetchWebhookUrl = async () => {
       try {
-        const data = await getIntegration(projectId, 'slack');
+        const data = await actionGetWebhookUrl(projectId);
         if (data) {
           setValue('webhookUrl', data.webhookUrl);
         }
@@ -54,7 +53,7 @@ export function SlackIntegration({ projectId }: { projectId: string }) {
 
   const onSubmit = async (data: { webhookUrl: string }) => {
     try {
-      const response = await saveWebhookUrl(projectId, data.webhookUrl);
+      const response = await actionSaveWebhookUrl(projectId, data.webhookUrl);
       if (response.success) {
         toast('Slack webhook URL saved successfully');
       } else {

--- a/apps/dbagent/src/evals/lib/mocking.ts
+++ b/apps/dbagent/src/evals/lib/mocking.ts
@@ -3,7 +3,7 @@ import * as connectionInfoExports from '~/lib/db/connection-info';
 import * as projectsExports from '~/lib/db/projects';
 
 export const mockGetProjectsById = () => {
-  vi.spyOn(projectsExports, 'getProjectById').mockImplementation(async (id) => {
+  vi.spyOn(projectsExports, 'getProjectById').mockImplementation(async (db, id) => {
     return { id, name: 'project name', cloudProvider: 'aws' };
   });
 };
@@ -11,7 +11,7 @@ export const mockGetProjectsById = () => {
 type GetConnectionInfoFunc = typeof connectionInfoExports.getConnectionInfo;
 
 // @ts-expect-error
-const defaultMock: GetConnectionInfoFunc = async (_connectionId, key) => {
+const defaultMock: GetConnectionInfoFunc = async (_db, _connectionId, key) => {
   if (key === 'tables') {
     return [
       {

--- a/apps/dbagent/src/lib/ai/aidba.ts
+++ b/apps/dbagent/src/lib/ai/aidba.ts
@@ -3,6 +3,7 @@ import { deepseek } from '@ai-sdk/deepseek';
 import { google } from '@ai-sdk/google';
 import { openai } from '@ai-sdk/openai';
 import { LanguageModelV1, Tool } from 'ai';
+import { Pool } from 'pg';
 import { Connection } from '~/lib/db/connections';
 import { getUserDBAccess } from '~/lib/db/db';
 import { Project } from '../db/projects';
@@ -55,29 +56,18 @@ export function getChatSystemPrompt(project: Project): string {
   }
 }
 
-interface DBTools {
-  tools: Record<string, Tool>;
-  end: () => Promise<void>;
-}
-
 export async function getTools(
   project: Project,
   connection: Connection,
-  asUserId?: string,
-  asProjectId?: string
-): Promise<DBTools> {
-  const projectId = asProjectId || connection.projectId;
+  targetDb: Pool,
+  asUserId?: string
+): Promise<Record<string, Tool>> {
   const dbAccess = await getUserDBAccess(asUserId);
 
-  const dbTools = getDBSQLTools(connection.connectionString);
-  const clusterTools = getDBClusterTools(dbAccess, project, connection);
-  const playbookToolset = getPlaybookToolset(dbAccess, projectId);
-  return {
-    tools: mergeToolsets(commonToolset, playbookToolset, dbTools, clusterTools),
-    end: async () => {
-      await dbTools.end();
-    }
-  };
+  const dbTools = getDBSQLTools(targetDb);
+  const clusterTools = getDBClusterTools(dbAccess, connection, project.cloudProvider);
+  const playbookToolset = getPlaybookToolset(dbAccess, project.id);
+  return mergeToolsets(commonToolset, playbookToolset, dbTools, clusterTools);
 }
 
 export function getModelInstance(model: string): LanguageModelV1 {

--- a/apps/dbagent/src/lib/ai/tools/cluster.ts
+++ b/apps/dbagent/src/lib/ai/tools/cluster.ts
@@ -2,19 +2,23 @@ import { tool, Tool } from 'ai';
 import { z } from 'zod';
 import { Connection } from '~/lib/db/connections';
 import { DBAccess } from '~/lib/db/db';
-import { Project } from '~/lib/db/projects';
+import { CloudProviderType } from '~/lib/db/projects';
 import { getPostgresExtensions, getTablesAndInstanceInfo } from '~/lib/tools/dbinfo';
 import { getInstanceLogsGCP, getInstanceLogsRDS } from '~/lib/tools/logs';
 import { getClusterMetricGCP, getClusterMetricRDS } from '~/lib/tools/metrics';
 import { mergeToolsets, Toolset, ToolsetGroup } from './types';
 
-export function getDBClusterTools(dbAccess: DBAccess, project: Project, connection: Connection): Record<string, Tool> {
+export function getDBClusterTools(
+  dbAccess: DBAccess,
+  connection: Connection,
+  cloudProvider: CloudProviderType
+): Record<string, Tool> {
   const connectionGetter = () => Promise.resolve({ connection });
   const toolset: Toolset[] = [new CommonDBClusterTools(dbAccess, connectionGetter)];
 
-  if (project.cloudProvider === 'aws') {
+  if (cloudProvider === 'aws') {
     toolset.push(new AWSDBClusterTools(dbAccess, connectionGetter));
-  } else if (project.cloudProvider === 'gcp') {
+  } else if (cloudProvider === 'gcp') {
     toolset.push(new GCPDBClusterTools(dbAccess, connectionGetter));
   }
   return mergeToolsets(...toolset);

--- a/apps/dbagent/src/lib/ai/tools/db.ts
+++ b/apps/dbagent/src/lib/ai/tools/db.ts
@@ -11,11 +11,10 @@ import {
 } from '~/lib/tools/stats';
 import { ToolsetGroup } from './types';
 
-import { getTargetDbPool, Pool, withPoolConnection } from '~/lib/targetdb/db';
+import { Pool, withPoolConnection } from '~/lib/targetdb/db';
 
-export function getDBSQLTools(connString: string): DBSQLTools {
-  const pool = getTargetDbPool(connString);
-  return new DBSQLTools(pool);
+export function getDBSQLTools(targetDb: Pool): DBSQLTools {
+  return new DBSQLTools(targetDb);
 }
 
 // The DBSQLTools toolset provides tools for querying the postgres database
@@ -25,11 +24,6 @@ export class DBSQLTools implements ToolsetGroup {
 
   constructor(pool: Pool | (() => Promise<Pool>)) {
     this.#pool = pool;
-  }
-
-  async end() {
-    const pool = typeof this.#pool === 'function' ? await this.#pool() : this.#pool;
-    await pool.end();
   }
 
   toolset(): Record<string, Tool> {

--- a/apps/dbagent/src/lib/ai/tools/db.ts
+++ b/apps/dbagent/src/lib/ai/tools/db.ts
@@ -21,14 +21,14 @@ export function getDBSQLTools(connString: string): DBSQLTools {
 // The DBSQLTools toolset provides tools for querying the postgres database
 // directly via SQL to collect system performance information.
 export class DBSQLTools implements ToolsetGroup {
-  private _pool: Pool | (() => Promise<Pool>);
+  #pool: Pool | (() => Promise<Pool>);
 
   constructor(pool: Pool | (() => Promise<Pool>)) {
-    this._pool = pool;
+    this.#pool = pool;
   }
 
   async end() {
-    const pool = typeof this._pool === 'function' ? await this._pool() : this._pool;
+    const pool = typeof this.#pool === 'function' ? await this.#pool() : this.#pool;
     await pool.end();
   }
 
@@ -48,7 +48,7 @@ export class DBSQLTools implements ToolsetGroup {
   }
 
   getSlowQueries(): Tool {
-    const pool = this._pool;
+    const pool = this.#pool;
     return tool({
       description: `Get a list of slow queries formatted as a JSON array. Contains how many times the query was called,
 the max execution time in seconds, the mean execution time in seconds, the total execution time
@@ -64,7 +64,7 @@ the max execution time in seconds, the mean execution time in seconds, the total
   }
 
   explainQuery(): Tool {
-    const pool = this._pool;
+    const pool = this.#pool;
     return tool({
       description: `Run explain on a a query. Returns the explain plan as received from PostgreSQL.
 The query needs to be complete, it cannot contain $1, $2, etc. If you need to, replace the parameters with your own made up values.
@@ -89,7 +89,7 @@ If you know the schema, pass it in as well.`,
   }
 
   describeTable(): Tool {
-    const pool = this._pool;
+    const pool = this.#pool;
     return tool({
       description: `Describe a table. If you know the schema, pass it as a parameter. If you don't, use public.`,
       parameters: z.object({
@@ -106,7 +106,7 @@ If you know the schema, pass it in as well.`,
   }
 
   findTableSchema(): Tool {
-    const pool = this._pool;
+    const pool = this.#pool;
     return tool({
       description: `Find the schema of a table. Use this tool to find the schema of a table.`,
       parameters: z.object({
@@ -119,7 +119,7 @@ If you know the schema, pass it in as well.`,
   }
 
   getCurrentActiveQueries(): Tool {
-    const pool = this._pool;
+    const pool = this.#pool;
     return tool({
       description: `Get the currently active queries.`,
       parameters: z.object({}),
@@ -130,7 +130,7 @@ If you know the schema, pass it in as well.`,
   }
 
   getQueriesWaitingOnLocks(): Tool {
-    const pool = this._pool;
+    const pool = this.#pool;
     return tool({
       description: `Get the queries that are currently blocked waiting on locks.`,
       parameters: z.object({}),
@@ -141,7 +141,7 @@ If you know the schema, pass it in as well.`,
   }
 
   getVacuumStats(): Tool {
-    const pool = this._pool;
+    const pool = this.#pool;
     return tool({
       description: `Get the vacuum stats for the top tables in the database. They are sorted by the number of dead tuples descending.`,
       parameters: z.object({}),
@@ -152,7 +152,7 @@ If you know the schema, pass it in as well.`,
   }
 
   getConnectionsStats(): Tool {
-    const pool = this._pool;
+    const pool = this.#pool;
     return tool({
       description: `Get the connections stats for the database.`,
       parameters: z.object({}),
@@ -163,7 +163,7 @@ If you know the schema, pass it in as well.`,
   }
 
   getConnectionsGroups(): Tool {
-    const pool = this._pool;
+    const pool = this.#pool;
     return tool({
       description: `Get the connections groups for the database. This is a view in the pg_stat_activity table, grouped by (state, user, application_name, client_addr, wait_event_type, wait_event).`,
       parameters: z.object({}),
@@ -174,7 +174,7 @@ If you know the schema, pass it in as well.`,
   }
 
   getPerformanceAndVacuumSettings(): Tool {
-    const pool = this._pool;
+    const pool = this.#pool;
     return tool({
       description: `Get the performance and vacuum settings for the database.`,
       parameters: z.object({}),

--- a/apps/dbagent/src/lib/ai/tools/playbook.ts
+++ b/apps/dbagent/src/lib/ai/tools/playbook.ts
@@ -1,21 +1,44 @@
 import { tool, Tool } from 'ai';
 import { z } from 'zod';
+import { DBAccess } from '~/lib/db/db';
 import { getCustomPlaybookAndPlaybookTool, listCustomPlaybooksAndPlaybookTool } from '~/lib/tools/custom-playbooks';
+import { getPlaybook, listPlaybooks } from '~/lib/tools/playbooks';
 import { ToolsetGroup } from './types';
 
-export function getPlaybookToolset(
-  connProjectId: string,
-  asUserId?: string,
-  asProjectId?: string
-): Record<string, Tool> {
-  return new playbookTools(() => Promise.resolve({ connProjectId, asUserId, asProjectId })).toolset();
+export function getPlaybookToolset(dbAccess: DBAccess, projectId: string): Record<string, Tool> {
+  return new playbookTools(dbAccess, () => Promise.resolve({ projectId })).toolset();
 }
 
-export class playbookTools implements ToolsetGroup {
-  private _connProjectId: () => Promise<{ connProjectId: string; asUserId?: string; asProjectId?: string }>;
+function playbookFetchTool(execute: (name: string) => Promise<string>): Tool {
+  return tool({
+    description: `Get a playbook contents by name. A playbook is a list of steps to follow to achieve a goal. Follow it step by step.`,
+    parameters: z.object({
+      name: z.string()
+    }),
+    execute: async ({ name }: { name: string }) => execute(name)
+  });
+}
 
-  constructor(getter: () => Promise<{ connProjectId: string; asUserId?: string; asProjectId?: string }>) {
-    this._connProjectId = getter;
+function playbookListTool(execute: () => Promise<string[]>): Tool {
+  return tool({
+    description: `List the available playbooks.`,
+    parameters: z.object({}),
+    execute: async () => execute()
+  });
+}
+
+export const builtinPlaybookToolset = {
+  getPlaybookTool: playbookFetchTool(async (name: string) => getPlaybook(name)),
+  listPlaybooksTool: playbookListTool(async () => listPlaybooks())
+};
+
+export class playbookTools implements ToolsetGroup {
+  #dbAccess: DBAccess;
+  #connProjectId: () => Promise<{ projectId: string }>;
+
+  constructor(dbAccess: DBAccess, getter: () => Promise<{ projectId: string }>) {
+    this.#dbAccess = dbAccess;
+    this.#connProjectId = getter;
   }
 
   toolset(): Record<string, Tool> {
@@ -26,28 +49,20 @@ export class playbookTools implements ToolsetGroup {
   }
 
   private getPlaybookTool(): Tool {
-    const getter = this._connProjectId;
-    return tool({
-      description: `Get a playbook contents by name. A playbook is a list of steps to follow to achieve a goal. Follow it step by step.`,
-      parameters: z.object({
-        name: z.string()
-      }),
-      execute: async ({ name }: { name: string }) => {
-        const { connProjectId, asUserId, asProjectId } = await getter();
-        return await getCustomPlaybookAndPlaybookTool(name, connProjectId, asUserId, asProjectId);
-      }
+    const db = this.#dbAccess;
+    const getter = this.#connProjectId;
+    return playbookFetchTool(async (name: string) => {
+      const { projectId } = await getter();
+      return await getCustomPlaybookAndPlaybookTool(db, name, projectId);
     });
   }
 
   private listPlaybooksTool(): Tool {
-    const getter = this._connProjectId;
-    return tool({
-      description: `List the available playbooks.`,
-      parameters: z.object({}),
-      execute: async () => {
-        const { connProjectId, asUserId, asProjectId } = await getter();
-        return await listCustomPlaybooksAndPlaybookTool(connProjectId, asUserId, asProjectId);
-      }
+    const db = this.#dbAccess;
+    const getter = this.#connProjectId;
+    return playbookListTool(async () => {
+      const { projectId } = await getter();
+      return await listCustomPlaybooksAndPlaybookTool(db, projectId);
     });
   }
 }

--- a/apps/dbagent/src/lib/db/aws-clusters.ts
+++ b/apps/dbagent/src/lib/db/aws-clusters.ts
@@ -2,7 +2,7 @@
 
 import { eq } from 'drizzle-orm';
 import { RDSClusterDetailedInfo } from '../aws/rds';
-import { queryDb } from './db';
+import { DBAccess } from './db';
 import { awsClusterConnections, awsClusters } from './schema';
 
 export type AWSCluster = {
@@ -13,8 +13,8 @@ export type AWSCluster = {
   data: RDSClusterDetailedInfo;
 };
 
-export async function saveCluster(cluster: Omit<AWSCluster, 'id'>): Promise<string> {
-  return queryDb(async ({ db }) => {
+export async function saveCluster(dbAccess: DBAccess, cluster: Omit<AWSCluster, 'id'>): Promise<string> {
+  return dbAccess.query(async ({ db }) => {
     const result = await db
       .insert(awsClusters)
       .values(cluster)
@@ -33,16 +33,19 @@ export async function saveCluster(cluster: Omit<AWSCluster, 'id'>): Promise<stri
   });
 }
 
-export async function associateClusterConnection({
-  projectId,
-  clusterId,
-  connectionId
-}: {
-  projectId: string;
-  clusterId: string;
-  connectionId: string;
-}): Promise<void> {
-  return queryDb(async ({ db }) => {
+export async function associateClusterConnection(
+  dbAccess: DBAccess,
+  {
+    projectId,
+    clusterId,
+    connectionId
+  }: {
+    projectId: string;
+    clusterId: string;
+    connectionId: string;
+  }
+): Promise<void> {
+  return dbAccess.query(async ({ db }) => {
     await db.insert(awsClusterConnections).values({
       projectId,
       clusterId,
@@ -51,25 +54,20 @@ export async function associateClusterConnection({
   });
 }
 
-export async function getClusterByConnection(connectionId: string, asUserId?: string): Promise<AWSCluster | null> {
-  return queryDb(
-    async ({ db }) => {
-      const result = await db
-        .select()
-        .from(awsClusters)
-        .innerJoin(awsClusterConnections, eq(awsClusterConnections.clusterId, awsClusters.id))
-        .where(eq(awsClusterConnections.connectionId, connectionId))
-        .limit(1);
-      return result[0]?.aws_clusters ?? null;
-    },
-    {
-      asUserId: asUserId
-    }
-  );
+export async function getClusterByConnection(dbAccess: DBAccess, connectionId: string): Promise<AWSCluster | null> {
+  return dbAccess.query(async ({ db }) => {
+    const result = await db
+      .select()
+      .from(awsClusters)
+      .innerJoin(awsClusterConnections, eq(awsClusterConnections.clusterId, awsClusters.id))
+      .where(eq(awsClusterConnections.connectionId, connectionId))
+      .limit(1);
+    return result[0]?.aws_clusters ?? null;
+  });
 }
 
-export async function getClusters(projectId: string): Promise<AWSCluster[]> {
-  return queryDb(async ({ db }) => {
+export async function getClusters(dbAccess: DBAccess, projectId: string): Promise<AWSCluster[]> {
+  return dbAccess.query(async ({ db }) => {
     return await db.select().from(awsClusters).where(eq(awsClusters.projectId, projectId));
   });
 }

--- a/apps/dbagent/src/lib/db/custom-playbooks.ts
+++ b/apps/dbagent/src/lib/db/custom-playbooks.ts
@@ -1,32 +1,29 @@
 'use server';
 
 import { and, eq } from 'drizzle-orm';
-import { queryDb } from '~/lib/db/db';
+import { DBAccess } from '~/lib/db/db';
 import { playbooks } from '~/lib/db/schema';
 import { customPlaybook } from '~/lib/tools/custom-playbooks';
 import { Playbook } from '~/lib/tools/playbooks';
 
-export async function dbGetCustomPlaybooks(projectId: string, asUserId?: string) {
-  return await queryDb(
-    async ({ db }) => {
-      const results = await db.select().from(playbooks).where(eq(playbooks.projectId, projectId));
+export async function dbGetCustomPlaybooks(dbAccess: DBAccess, projectId: string) {
+  return await dbAccess.query(async ({ db }) => {
+    const results = await db.select().from(playbooks).where(eq(playbooks.projectId, projectId));
 
-      return results.map((playbook) => ({
-        name: playbook.name,
-        description: playbook.description || '',
-        content: playbook.content as string,
-        id: playbook.id,
-        projectId: playbook.projectId,
-        isBuiltIn: false,
-        createdBy: playbook.createdBy
-      }));
-    },
-    { asUserId }
-  );
+    return results.map((playbook) => ({
+      name: playbook.name,
+      description: playbook.description || '',
+      content: playbook.content as string,
+      id: playbook.id,
+      projectId: playbook.projectId,
+      isBuiltIn: false,
+      createdBy: playbook.createdBy
+    }));
+  });
 }
 
-export async function dbCreatePlaybook(input: customPlaybook): Promise<Playbook> {
-  return await queryDb(async ({ db, userId }) => {
+export async function dbCreatePlaybook(dbAccess: DBAccess, input: customPlaybook): Promise<Playbook> {
+  return await dbAccess.query(async ({ db, userId }) => {
     //checks if playbooks with same name and id in db
     const existingPlaybook = await db
       .select()
@@ -67,10 +64,11 @@ export async function dbCreatePlaybook(input: customPlaybook): Promise<Playbook>
 }
 
 export async function dbUpdatePlaybook(
+  dbAccess: DBAccess,
   id: string,
   input: { description?: string; content?: string }
 ): Promise<Playbook | null> {
-  return await queryDb(async ({ db }) => {
+  return await dbAccess.query(async ({ db }) => {
     const result = await db
       .update(playbooks)
       .set({
@@ -95,8 +93,8 @@ export async function dbUpdatePlaybook(
   });
 }
 
-export async function dbDeletePlaybook(id: string): Promise<void> {
-  return await queryDb(async ({ db }) => {
+export async function dbDeletePlaybook(dbAccess: DBAccess, id: string): Promise<void> {
+  return await dbAccess.query(async ({ db }) => {
     const result = await db.delete(playbooks).where(eq(playbooks.id, id)).returning();
 
     if (result.length === 0) {

--- a/apps/dbagent/src/lib/db/db.ts
+++ b/apps/dbagent/src/lib/db/db.ts
@@ -77,7 +77,7 @@ export async function getUserSessionDBAccess(): Promise<DBAccess> {
   return new DBUserAccess(session.user.id!);
 }
 
-export async function getUserDBAccess(userId?: string): Promise<DBAccess> {
+export async function getUserDBAccess(userId: string | undefined | null): Promise<DBAccess> {
   if (!userId) {
     return getUserSessionDBAccess();
   }

--- a/apps/dbagent/src/lib/db/gcp-instances.ts
+++ b/apps/dbagent/src/lib/db/gcp-instances.ts
@@ -32,15 +32,18 @@ export async function saveInstance(dbAccess: DBAccess, instance: Omit<GCPInstanc
   });
 }
 
-export async function associateInstanceConnection(dbAccess: DBAccess, {
-  projectId,
-  instanceId,
-  connectionId
-}: {
-  projectId: string;
-  instanceId: string;
-  connectionId: string;
-}): Promise<void> {
+export async function associateInstanceConnection(
+  dbAccess: DBAccess,
+  {
+    projectId,
+    instanceId,
+    connectionId
+  }: {
+    projectId: string;
+    instanceId: string;
+    connectionId: string;
+  }
+): Promise<void> {
   return dbAccess.query(async ({ db }) => {
     await db.insert(gcpInstanceConnections).values({
       projectId,

--- a/apps/dbagent/src/lib/db/gcp-instances.ts
+++ b/apps/dbagent/src/lib/db/gcp-instances.ts
@@ -2,7 +2,7 @@
 
 import { eq } from 'drizzle-orm';
 import { CloudSQLInstanceInfo } from '../gcp/cloudsql';
-import { queryDb } from './db';
+import { DBAccess } from './db';
 import { gcpInstanceConnections, gcpInstances } from './schema';
 
 export type GCPInstance = {
@@ -13,8 +13,8 @@ export type GCPInstance = {
   data: CloudSQLInstanceInfo;
 };
 
-export async function saveInstance(instance: Omit<GCPInstance, 'id'>): Promise<string> {
-  return queryDb(async ({ db }) => {
+export async function saveInstance(dbAccess: DBAccess, instance: Omit<GCPInstance, 'id'>): Promise<string> {
+  return dbAccess.query(async ({ db }) => {
     const result = await db
       .insert(gcpInstances)
       .values(instance)
@@ -32,7 +32,7 @@ export async function saveInstance(instance: Omit<GCPInstance, 'id'>): Promise<s
   });
 }
 
-export async function associateInstanceConnection({
+export async function associateInstanceConnection(dbAccess: DBAccess, {
   projectId,
   instanceId,
   connectionId
@@ -41,7 +41,7 @@ export async function associateInstanceConnection({
   instanceId: string;
   connectionId: string;
 }): Promise<void> {
-  return queryDb(async ({ db }) => {
+  return dbAccess.query(async ({ db }) => {
     await db.insert(gcpInstanceConnections).values({
       projectId,
       instanceId,
@@ -50,25 +50,20 @@ export async function associateInstanceConnection({
   });
 }
 
-export async function getInstanceByConnection(connectionId: string, asUserId?: string): Promise<GCPInstance | null> {
-  return queryDb(
-    async ({ db }) => {
-      const result = await db
-        .select()
-        .from(gcpInstances)
-        .innerJoin(gcpInstanceConnections, eq(gcpInstanceConnections.instanceId, gcpInstances.id))
-        .where(eq(gcpInstanceConnections.connectionId, connectionId))
-        .limit(1);
-      return result[0]?.gcp_instances ?? null;
-    },
-    {
-      asUserId: asUserId
-    }
-  );
+export async function getInstanceByConnection(dbAccess: DBAccess, connectionId: string): Promise<GCPInstance | null> {
+  return dbAccess.query(async ({ db }) => {
+    const result = await db
+      .select()
+      .from(gcpInstances)
+      .innerJoin(gcpInstanceConnections, eq(gcpInstanceConnections.instanceId, gcpInstances.id))
+      .where(eq(gcpInstanceConnections.connectionId, connectionId))
+      .limit(1);
+    return result[0]?.gcp_instances ?? null;
+  });
 }
 
-export async function getInstances(projectId: string): Promise<GCPInstance[]> {
-  return queryDb(async ({ db }) => {
+export async function getInstances(dbAccess: DBAccess, projectId: string): Promise<GCPInstance[]> {
+  return dbAccess.query(async ({ db }) => {
     return await db.select().from(gcpInstances).where(eq(gcpInstances.projectId, projectId));
   });
 }

--- a/apps/dbagent/src/lib/db/integrations.ts
+++ b/apps/dbagent/src/lib/db/integrations.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { and, eq } from 'drizzle-orm';
-import { queryDb } from './db';
+import { DBAccess } from './db';
 import { integrations } from './schema';
 
 export type AwsIntegration = {
@@ -37,8 +37,8 @@ type IntegrationTypes =
 export async function saveIntegration<
   Key extends IntegrationTypes['type'],
   Value extends IntegrationTypes & { type: Key }
->(projectId: string, name: Key, data: Value['data']) {
-  return queryDb(async ({ db }) => {
+>(dbAccess: DBAccess, projectId: string, name: Key, data: Value['data']) {
+  return dbAccess.query(async ({ db }) => {
     await db
       .insert(integrations)
       .values({
@@ -58,18 +58,13 @@ export async function saveIntegration<
 export async function getIntegration<
   Key extends IntegrationTypes['type'],
   Value extends IntegrationTypes & { type: Key }
->(projectId: string, name: Key, asUserId?: string): Promise<Value['data'] | null> {
-  return queryDb(
-    async ({ db }) => {
-      const result = await db
-        .select()
-        .from(integrations)
-        .where(and(eq(integrations.projectId, projectId), eq(integrations.name, name)));
+>(dbAccess: DBAccess, projectId: string, name: Key): Promise<Value['data'] | null> {
+  return dbAccess.query(async ({ db }) => {
+    const result = await db
+      .select()
+      .from(integrations)
+      .where(and(eq(integrations.projectId, projectId), eq(integrations.name, name)));
 
-      return (result[0]?.data as Value['data']) || null;
-    },
-    {
-      asUserId: asUserId
-    }
-  );
+    return (result[0]?.data as Value['data']) || null;
+  });
 }

--- a/apps/dbagent/src/lib/db/schedule-runs.ts
+++ b/apps/dbagent/src/lib/db/schedule-runs.ts
@@ -2,7 +2,7 @@
 
 import { Message } from '@ai-sdk/ui-utils';
 import { desc, eq, lt } from 'drizzle-orm';
-import { queryDb } from './db';
+import { DBAccess } from './db';
 import { scheduleRuns } from './schema';
 
 export type ScheduleRun = {
@@ -17,56 +17,54 @@ export type ScheduleRun = {
 };
 
 export async function insertScheduleRunLimitHistory(
+  dbAccess: DBAccess,
   scheduleRun: Omit<ScheduleRun, 'id'>,
-  keepHistory: number,
-  asUserId?: string
+  keepHistory: number
 ): Promise<ScheduleRun> {
-  return queryDb(
-    async ({ db }) => {
-      // Insert the new run first
-      const result = await db.insert(scheduleRuns).values(scheduleRun).returning();
-      if (!result[0]) {
-        throw new Error('Failed to insert schedule run');
-      }
-      const newRun = result[0];
-
-      // Count total runs for this schedule
-      const totalRuns = await db
-        .select({ count: scheduleRuns.id })
-        .from(scheduleRuns)
-        .where(eq(scheduleRuns.scheduleId, scheduleRun.scheduleId));
-      const count = Number(totalRuns[0]?.count) || 0;
-
-      // If we haven't exceeded keepHistory limit yet, no need to delete anything
-      if (count <= keepHistory) {
-        return newRun;
-      }
-
-      // Find the last schedule to keep based on keepHistory
-      const lastScheduleToKeep = await db
-        .select()
-        .from(scheduleRuns)
-        .where(eq(scheduleRuns.scheduleId, scheduleRun.scheduleId))
-        .orderBy(desc(scheduleRuns.createdAt))
-        .offset(keepHistory - 1)
-        .limit(1);
-      const cutoffTimestamp = lastScheduleToKeep[0]?.createdAt;
-      if (!cutoffTimestamp) {
-        throw new Error('Failed to find cutoff timestamp');
-      }
-
-      // Delete older runs beyond the history limit
-      await db.delete(scheduleRuns).where(lt(scheduleRuns.createdAt, cutoffTimestamp));
-      return newRun;
-    },
-    {
-      asUserId: asUserId
+  return dbAccess.query(async ({ db }) => {
+    // Insert the new run first
+    const result = await db.insert(scheduleRuns).values(scheduleRun).returning();
+    if (!result[0]) {
+      throw new Error('Failed to insert schedule run');
     }
-  );
+    const newRun = result[0];
+
+    // Count total runs for this schedule
+    const totalRuns = await db
+      .select({ count: scheduleRuns.id })
+      .from(scheduleRuns)
+      .where(eq(scheduleRuns.scheduleId, scheduleRun.scheduleId));
+    const count = Number(totalRuns[0]?.count) || 0;
+
+    // If we haven't exceeded keepHistory limit yet, no need to delete anything
+    if (count <= keepHistory) {
+      return newRun;
+    }
+
+    // Find the last schedule to keep based on keepHistory
+    const lastScheduleToKeep = await db
+      .select()
+      .from(scheduleRuns)
+      .where(eq(scheduleRuns.scheduleId, scheduleRun.scheduleId))
+      .orderBy(desc(scheduleRuns.createdAt))
+      .offset(keepHistory - 1)
+      .limit(1);
+    const cutoffTimestamp = lastScheduleToKeep[0]?.createdAt;
+    if (!cutoffTimestamp) {
+      throw new Error('Failed to find cutoff timestamp');
+    }
+
+    // Delete older runs beyond the history limit
+    await db.delete(scheduleRuns).where(lt(scheduleRuns.createdAt, cutoffTimestamp));
+    return newRun;
+  });
 }
 
-export async function insertScheduleRun(scheduleRun: Omit<ScheduleRun, 'id'>) {
-  return queryDb(async ({ db }) => {
+export async function insertScheduleRun(
+  dbAccess: DBAccess,
+  scheduleRun: Omit<ScheduleRun, 'id'>
+): Promise<ScheduleRun> {
+  return dbAccess.query(async ({ db }) => {
     const result = await db.insert(scheduleRuns).values(scheduleRun).returning();
     if (!result[0]) {
       throw new Error('Failed to insert schedule run');
@@ -75,8 +73,8 @@ export async function insertScheduleRun(scheduleRun: Omit<ScheduleRun, 'id'>) {
   });
 }
 
-export async function getScheduleRuns(scheduleId: string): Promise<ScheduleRun[]> {
-  return queryDb(async ({ db }) => {
+export async function getScheduleRuns(dbAccess: DBAccess, scheduleId: string): Promise<ScheduleRun[]> {
+  return dbAccess.query(async ({ db }) => {
     return await db
       .select()
       .from(scheduleRuns)
@@ -85,8 +83,8 @@ export async function getScheduleRuns(scheduleId: string): Promise<ScheduleRun[]
   });
 }
 
-export async function getScheduleRun(runId: string): Promise<ScheduleRun> {
-  return queryDb(async ({ db }) => {
+export async function getScheduleRun(dbAccess: DBAccess, runId: string): Promise<ScheduleRun> {
+  return dbAccess.query(async ({ db }) => {
     const result = await db.select().from(scheduleRuns).where(eq(scheduleRuns.id, runId));
     if (!result[0]) {
       throw new Error('Schedule run not found');

--- a/apps/dbagent/src/lib/db/schedules.ts
+++ b/apps/dbagent/src/lib/db/schedules.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { and, eq, sql } from 'drizzle-orm';
-import { queryDb } from './db';
+import { DBAccess } from './db';
 import { schedules } from './schema';
 
 export type Schedule = {
@@ -27,8 +27,8 @@ export type Schedule = {
   extraNotificationText?: string | null;
 };
 
-export async function insertSchedule(schedule: Omit<Schedule, 'id'>): Promise<Schedule> {
-  return await queryDb(async ({ db }) => {
+export async function insertSchedule(dbAccess: DBAccess, schedule: Omit<Schedule, 'id'>): Promise<Schedule> {
+  return await dbAccess.query(async ({ db }) => {
     const result = await db.insert(schedules).values(schedule).returning();
     if (!result[0]) {
       throw new Error('Failed to insert schedule');
@@ -37,8 +37,8 @@ export async function insertSchedule(schedule: Omit<Schedule, 'id'>): Promise<Sc
   });
 }
 
-export async function updateSchedule(schedule: Schedule): Promise<Schedule> {
-  return await queryDb(async ({ db }) => {
+export async function updateSchedule(dbAccess: DBAccess, schedule: Schedule): Promise<Schedule> {
+  return await dbAccess.query(async ({ db }) => {
     const result = await db.update(schedules).set(schedule).where(eq(schedules.id, schedule.id)).returning();
     if (!result[0]) {
       throw new Error(`Schedule with id ${schedule.id} not found`);
@@ -47,14 +47,20 @@ export async function updateSchedule(schedule: Schedule): Promise<Schedule> {
   });
 }
 
-export async function getSchedules(): Promise<Schedule[]> {
-  return await queryDb(async ({ db }) => {
+export async function getSchedules(dbAccess: DBAccess): Promise<Schedule[]> {
+  return await dbAccess.query(async ({ db }) => {
     return await db.select().from(schedules);
   });
 }
 
-export async function getSchedule(id: string): Promise<Schedule> {
-  return await queryDb(async ({ db }) => {
+export async function getSchedulesByProjectId(dbAccess: DBAccess, projectId: string): Promise<Schedule[]> {
+  return await dbAccess.query(async ({ db }) => {
+    return await db.select().from(schedules).where(eq(schedules.projectId, projectId));
+  });
+}
+
+export async function getSchedule(dbAccess: DBAccess, id: string): Promise<Schedule> {
+  return await dbAccess.query(async ({ db }) => {
     const result = await db.select().from(schedules).where(eq(schedules.id, id));
     if (!result[0]) {
       throw new Error(`Schedule with id ${id} not found`);
@@ -64,8 +70,12 @@ export async function getSchedule(id: string): Promise<Schedule> {
 }
 
 //get schedules by userId and projectId used to check if customPlaybook is being used to monitor a database, inorder to notify a user before they delete it
-export async function getSchedulesByUserIdAndProjectId(userId: string, projectId: string): Promise<Schedule[]> {
-  return await queryDb(async ({ db }) => {
+export async function getSchedulesByUserIdAndProjectId(
+  dbAccess: DBAccess,
+  userId: string,
+  projectId: string
+): Promise<Schedule[]> {
+  return await dbAccess.query(async ({ db }) => {
     return await db
       .select()
       .from(schedules)
@@ -73,62 +83,47 @@ export async function getSchedulesByUserIdAndProjectId(userId: string, projectId
   });
 }
 
-export async function deleteSchedule(id: string): Promise<void> {
-  return await queryDb(async ({ db }) => {
+export async function deleteSchedule(dbAccess: DBAccess, id: string): Promise<void> {
+  return await dbAccess.query(async ({ db }) => {
     await db.delete(schedules).where(eq(schedules.id, id));
   });
 }
 
-export async function incrementScheduleFailures(schedule: Schedule): Promise<void> {
-  return await queryDb(
-    async ({ db }) => {
-      await db
-        .update(schedules)
-        .set({ failures: sql`${schedules.failures} + 1` })
-        .where(eq(schedules.id, schedule.id));
-    },
-    {
-      asUserId: schedule.userId
-    }
-  );
+export async function incrementScheduleFailures(dbAccess: DBAccess, schedule: Schedule): Promise<void> {
+  return await dbAccess.query(async ({ db }) => {
+    await db
+      .update(schedules)
+      .set({ failures: sql`${schedules.failures} + 1` })
+      .where(eq(schedules.id, schedule.id));
+  });
 }
 
-export async function setScheduleStatusRunning(schedule: Schedule): Promise<void> {
-  return await queryDb(
-    async ({ db }) => {
-      await db.transaction(async (trx) => {
-        const result = await trx
-          .select({ status: schedules.status })
-          .from(schedules)
-          .for('update')
-          .where(eq(schedules.id, schedule.id));
-        if (result[0]?.status === 'running') {
-          throw new Error(`Schedule ${schedule.id} is already running`);
-        }
-        await trx.update(schedules).set({ status: 'running' }).where(eq(schedules.id, schedule.id));
-      });
-    },
-    {
-      asUserId: schedule.userId
-    }
-  );
+export async function setScheduleStatusRunning(dbAccess: DBAccess, schedule: Schedule): Promise<void> {
+  return await dbAccess.query(async ({ db }) => {
+    await db.transaction(async (trx) => {
+      const result = await trx
+        .select({ status: schedules.status })
+        .from(schedules)
+        .for('update')
+        .where(eq(schedules.id, schedule.id));
+      if (result[0]?.status === 'running') {
+        throw new Error(`Schedule ${schedule.id} is already running`);
+      }
+      await trx.update(schedules).set({ status: 'running' }).where(eq(schedules.id, schedule.id));
+    });
+  });
 }
 
-export async function updateScheduleRunData(schedule: Schedule): Promise<void> {
-  return await queryDb(
-    async ({ db }) => {
-      await db
-        .update(schedules)
-        .set({
-          nextRun: schedule.nextRun || null,
-          lastRun: schedule.lastRun || null,
-          status: schedule.status,
-          enabled: schedule.enabled
-        })
-        .where(eq(schedules.id, schedule.id));
-    },
-    {
-      asUserId: schedule.userId
-    }
-  );
+export async function updateScheduleRunData(dbAccess: DBAccess, schedule: Schedule): Promise<void> {
+  return await dbAccess.query(async ({ db }) => {
+    await db
+      .update(schedules)
+      .set({
+        nextRun: schedule.nextRun || null,
+        lastRun: schedule.lastRun || null,
+        status: schedule.status,
+        enabled: schedule.enabled
+      })
+      .where(eq(schedules.id, schedule.id));
+  });
 }

--- a/apps/dbagent/src/lib/monitoring/runner.ts
+++ b/apps/dbagent/src/lib/monitoring/runner.ts
@@ -3,6 +3,7 @@ import { generateId, generateObject, generateText, LanguageModelV1 } from 'ai';
 import { z } from 'zod';
 import { getModelInstance, getMonitoringSystemPrompt, getTools } from '../ai/aidba';
 import { Connection, getConnectionFromSchedule } from '../db/connections';
+import { DBAccess } from '../db/db';
 import { getProjectById, Project } from '../db/projects';
 import { insertScheduleRunLimitHistory, ScheduleRun } from '../db/schedule-runs';
 import { Schedule } from '../db/schedules';
@@ -184,16 +185,16 @@ function shouldNotify(notifyLevel: 'alert' | 'warning' | 'info', notificationLev
   return levelMap[notificationLevel] >= levelMap[notifyLevel];
 }
 
-export async function runSchedule(schedule: Schedule, now: Date) {
+export async function runSchedule(dbAccess: DBAccess, schedule: Schedule, now: Date) {
   console.log(`Running schedule ${schedule.id}`);
 
-  const connection = await getConnectionFromSchedule(schedule);
+  const connection = await getConnectionFromSchedule(dbAccess, schedule);
   if (!connection) {
     throw new Error(`Connection ${schedule.connectionId} not found`);
   }
   const modelInstance = getModelInstance(schedule.model);
   const messages: Message[] = [];
-  const project = await getProjectById(connection.projectId, schedule.userId);
+  const project = await getProjectById(dbAccess, connection.projectId);
   if (!project) {
     throw new Error(`Project ${connection.projectId} not found`);
   }
@@ -257,10 +258,11 @@ export async function runSchedule(schedule: Schedule, now: Date) {
     messages: messages,
     createdAt: now.toISOString() // using the start time
   };
-  const run = await insertScheduleRunLimitHistory(scheduleRun, schedule.keepHistory, schedule.userId);
+  const run = await insertScheduleRunLimitHistory(dbAccess, scheduleRun, schedule.keepHistory);
 
   if (shouldNotify(schedule.notifyLevel, notificationResult.notificationLevel)) {
     await sendScheduleNotification(
+      dbAccess,
       run,
       schedule,
       connection,

--- a/apps/dbagent/src/lib/notifications/slack-webhook.ts
+++ b/apps/dbagent/src/lib/notifications/slack-webhook.ts
@@ -1,4 +1,5 @@
 import { Connection } from '../db/connections';
+import { DBAccess } from '../db/db';
 import { getIntegration } from '../db/integrations';
 import { ScheduleRun } from '../db/schedule-runs';
 import { Schedule } from '../db/schedules';
@@ -7,6 +8,7 @@ import { env } from '../env/client';
 export type NotificationLevel = 'info' | 'warning' | 'alert';
 
 export async function sendScheduleNotification(
+  dbAccess: DBAccess,
   run: ScheduleRun,
   schedule: Schedule,
   connection: Connection,
@@ -15,7 +17,7 @@ export async function sendScheduleNotification(
   message: string,
   extraNotificationText?: string
 ) {
-  const slack = await getIntegration(connection.projectId, 'slack', schedule.userId);
+  const slack = await getIntegration(dbAccess, connection.projectId, 'slack');
   if (!slack) {
     console.error('No Slack integration configured.');
     return;

--- a/apps/dbagent/src/lib/targetdb/db.ts
+++ b/apps/dbagent/src/lib/targetdb/db.ts
@@ -150,18 +150,18 @@ export interface PerformanceSetting {
 
 export async function getPerformanceSettings(client: ClientBase): Promise<PerformanceSetting[]> {
   const result = await client.query(`
-      SELECT 
+      SELECT
         name,
         setting,
         unit,
         source,
-        short_desc as description 
-      FROM pg_settings 
+        short_desc as description
+      FROM pg_settings
       WHERE name IN (
         'max_connections',
         'work_mem',
         'shared_buffers',
-        'maintenance_work_mem', 
+        'maintenance_work_mem',
         'lock_timeout',
         'idle_in_transaction_session_timeout',
         'checkpoint_completion_target',
@@ -183,10 +183,10 @@ export async function getPerformanceSettings(client: ClientBase): Promise<Perfor
 
 export async function getVacuumSettings(client: ClientBase): Promise<PerformanceSetting[]> {
   const result = await client.query(`
-      SELECT 
+      SELECT
         name,
         setting,
-        unit, 
+        unit,
         source,
         short_desc as description
       FROM pg_settings
@@ -213,17 +213,17 @@ export interface ActiveQuery {
 
 export async function getCurrentActiveQueries(client: ClientBase): Promise<ActiveQuery[]> {
   const result = await client.query(`
-      SELECT 
+      SELECT
         pid,
         state,
         EXTRACT(EPOCH FROM (NOW() - query_start))::INTEGER as duration,
         wait_event_type,
         wait_event,
         query
-      FROM pg_stat_activity 
+      FROM pg_stat_activity
       WHERE state != 'idle'
         AND pid != pg_backend_pid()
-      ORDER BY duration DESC 
+      ORDER BY duration DESC
       LIMIT 500;
     `);
   return result.rows;
@@ -240,7 +240,7 @@ export interface BlockedQuery {
 export async function getQueriesWaitingOnLocks(client: ClientBase): Promise<BlockedQuery[]> {
   const result = await client.query(`
       WITH blocked_queries AS (
-        SELECT 
+        SELECT
           blocked.pid as blocked_pid,
           blocked.query as blocked_query,
           blocking.pid as blocking_pid,
@@ -332,7 +332,7 @@ export interface ConnectionDetails {
 
 export async function getConnectionsGroups(client: ClientBase): Promise<ConnectionDetails[]> {
   const result = await client.query(`
-SELECT 
+SELECT
     count(*) AS total_connections,
     state,
     usename AS user,
@@ -341,12 +341,12 @@ SELECT
     wait_event_type,
     wait_event
 FROM pg_stat_activity
-GROUP BY 
-    state, 
-    usename, 
-    application_name, 
-    client_addr, 
-    wait_event_type, 
+GROUP BY
+    state,
+    usename,
+    application_name,
+    client_addr,
+    wait_event_type,
     wait_event
 ORDER BY total_connections DESC;`);
   return result.rows;
@@ -369,15 +369,15 @@ interface SlowQuery {
 
 export async function getSlowQueries(client: ClientBase, thresholdMs: number): Promise<SlowQuery[]> {
   const query = `
-    SELECT 
+    SELECT
       calls,
       round(max_exec_time/1000) max_exec_secs,
-      round(mean_exec_time/1000) mean_exec_secs, 
+      round(mean_exec_time/1000) mean_exec_secs,
       round(total_exec_time/1000) total_exec_secs,
-      query 
-    FROM pg_stat_statements 
-    WHERE max_exec_time > $1 
-    ORDER BY total_exec_time DESC 
+      query
+    FROM pg_stat_statements
+    WHERE max_exec_time > $1
+    ORDER BY total_exec_time DESC
     LIMIT 10;
   `;
   const result = await client.query(query, [thresholdMs]);
@@ -411,13 +411,13 @@ export async function describeTable(client: ClientBase, schema: string, table: s
   console.log('table', table);
   // Get column information
   const columnQuery = `
-    SELECT 
+    SELECT
       column_name,
       data_type,
       is_nullable,
       column_default
     FROM information_schema.columns
-    WHERE table_schema = $1 
+    WHERE table_schema = $1
     AND table_name = $2
     ORDER BY ordinal_position;
   `;
@@ -481,10 +481,10 @@ export async function describeTable(client: ClientBase, schema: string, table: s
 export async function findTableSchema(client: ClientBase, table: string): Promise<string> {
   const result = await client.query(
     `
-      SELECT 
+      SELECT
       schemaname as schema,
       pg_total_relation_size(schemaname || '.' || tablename) as total_bytes
-    FROM pg_tables 
+    FROM pg_tables
     WHERE tablename = $1
     ORDER BY total_bytes DESC
     LIMIT 1;

--- a/apps/dbagent/src/lib/tools/custom-playbooks.ts
+++ b/apps/dbagent/src/lib/tools/custom-playbooks.ts
@@ -1,4 +1,5 @@
 import { dbGetCustomPlaybooks } from '../db/custom-playbooks';
+import { DBAccess } from '../db/db';
 import { getPlaybook, listPlaybooks } from './playbooks';
 export interface customPlaybook {
   name: string;
@@ -11,12 +12,12 @@ export interface customPlaybook {
 }
 
 //get a list of custom playbooks using projectId
-export async function getCustomPlaybooks(projectId: string, asUserId?: string): Promise<customPlaybook[]> {
+export async function getCustomPlaybooks(dbAccess: DBAccess, projectId: string): Promise<customPlaybook[]> {
   if (!projectId) {
     throw new Error('[INVALID_INPUT] Project ID is required');
   }
   try {
-    return await dbGetCustomPlaybooks(projectId, asUserId);
+    return await dbGetCustomPlaybooks(dbAccess, projectId);
   } catch (error) {
     console.error('Error in actionGetCustomPlaybooks:', error);
     throw new Error('Failed to get custom playbooks');
@@ -24,8 +25,8 @@ export async function getCustomPlaybooks(projectId: string, asUserId?: string): 
 }
 
 //get a custom playbook by id
-export async function getCustomPlaybook(projectId: string, id: string, asUserId?: string): Promise<customPlaybook> {
-  const customPlaybooks = await getCustomPlaybooks(projectId, asUserId);
+export async function getCustomPlaybook(dbAccess: DBAccess, projectId: string, id: string): Promise<customPlaybook> {
+  const customPlaybooks = await getCustomPlaybooks(dbAccess, projectId);
   const customPlaybook = customPlaybooks.find((playbook) => playbook.id === id);
   if (!customPlaybook) {
     throw new Error('Custom playbook not found');
@@ -35,9 +36,9 @@ export async function getCustomPlaybook(projectId: string, id: string, asUserId?
 
 //get a custom playbook by name
 export async function getCustomPlaybookByName(
+  dbAccess: DBAccess,
   projectId: string,
-  name: string,
-  asUserId?: string
+  name: string
 ): Promise<customPlaybook | null> {
   if (!projectId) {
     throw new Error('Project ID is required');
@@ -47,7 +48,7 @@ export async function getCustomPlaybookByName(
   }
 
   try {
-    const customPlaybooks = await getCustomPlaybooks(projectId, asUserId);
+    const customPlaybooks = await getCustomPlaybooks(dbAccess, projectId);
     const customPlaybook = customPlaybooks.find((playbook) => playbook.name === name);
 
     if (!customPlaybook) {
@@ -62,9 +63,9 @@ export async function getCustomPlaybookByName(
 }
 
 //get a list of custom playbooks names
-export async function getListOfCustomPlaybooksNames(projectId: string, asUserId?: string): Promise<string[] | null> {
+export async function getListOfCustomPlaybooksNames(dbAccess: DBAccess, projectId: string): Promise<string[] | null> {
   try {
-    const customPlaybooks = await getCustomPlaybooks(projectId, asUserId);
+    const customPlaybooks = await getCustomPlaybooks(dbAccess, projectId);
     const customPlaybooksNames = customPlaybooks.map((playbook) => playbook.name);
     return customPlaybooksNames.length === 0 ? null : customPlaybooksNames;
   } catch (error) {
@@ -75,12 +76,12 @@ export async function getListOfCustomPlaybooksNames(projectId: string, asUserId?
 
 //get a custom playbook content by name
 export async function getCustomPlaybookContent(
+  dbAccess: DBAccess,
   projectId: string,
-  name: string,
-  asUserId?: string
+  name: string
 ): Promise<string | null> {
   try {
-    const playbookWithDesc = await getCustomPlaybookByName(projectId, name, asUserId);
+    const playbookWithDesc = await getCustomPlaybookByName(dbAccess, projectId, name);
     return playbookWithDesc?.content ?? null;
   } catch (error) {
     console.error('Error in getCustomPlaybookContent:', error);
@@ -89,29 +90,16 @@ export async function getCustomPlaybookContent(
 }
 
 //gets content for either a custom playbook or a built in playbook
-export async function getCustomPlaybookAndPlaybookTool(
-  name: string,
-  connProjectId: string,
-  asUserId?: string,
-  asProjectId?: string
-): Promise<string> {
+export async function getCustomPlaybookAndPlaybookTool(db: DBAccess, name: string, projectId: string): Promise<string> {
   const playBookContent = getPlaybook(name);
-  //im not sure this is needed as asProjectId and connProjectId might be the same when ran in runners.ts
-  const projectId = asProjectId || connProjectId;
-  const customPlaybookContent = await getCustomPlaybookContent(projectId, name, asUserId);
-
+  const customPlaybookContent = await getCustomPlaybookContent(db, projectId, name);
   return customPlaybookContent !== null ? customPlaybookContent : playBookContent;
 }
 
 //gets a list of custom playbooks and built in playbooks
-export async function listCustomPlaybooksAndPlaybookTool(
-  connProjectId: string,
-  asUserId?: string,
-  asProjectId?: string
-): Promise<string[]> {
+export async function listCustomPlaybooksAndPlaybookTool(dbAccess: DBAccess, projectId: string): Promise<string[]> {
   const playbookNames = listPlaybooks();
-  const projectId = asProjectId || connProjectId;
-  const customPlaybookNames = await getListOfCustomPlaybooksNames(projectId, asUserId);
+  const customPlaybookNames = await getListOfCustomPlaybooksNames(dbAccess, projectId);
 
   return customPlaybookNames !== null ? [...playbookNames, ...customPlaybookNames] : playbookNames;
 }

--- a/apps/dbagent/src/lib/tools/dbinfo.ts
+++ b/apps/dbagent/src/lib/tools/dbinfo.ts
@@ -1,12 +1,13 @@
+import { DBAccess } from '~/lib/db/db';
 import { getConnectionInfo } from '../db/connection-info';
 import { Connection } from '../db/connections';
 import { getProjectById } from '../db/projects';
 import { ClientBase, findTableSchema, getPerformanceSettings, getVacuumSettings } from '../targetdb/db';
 
-export async function getTablesAndInstanceInfo(connection: Connection, asUserId?: string): Promise<string> {
+export async function getTablesAndInstanceInfo(dbAccess: DBAccess, connection: Connection): Promise<string> {
   try {
-    const tables = await getConnectionInfo(connection.id, 'tables', asUserId);
-    const project = await getProjectById(connection.projectId, asUserId);
+    const tables = await getConnectionInfo(dbAccess, connection.id, 'tables');
+    const project = await getProjectById(dbAccess, connection.projectId);
 
     return `
 Here are the tables, their sizes, and usage counts:
@@ -33,8 +34,8 @@ Vacuum settings: ${JSON.stringify(vacuumSettings)}
 `;
 }
 
-export async function getPostgresExtensions(connection: Connection, asUserId?: string): Promise<string> {
-  const extensions = await getConnectionInfo(connection.id, 'extensions', asUserId);
+export async function getPostgresExtensions(dbAccess: DBAccess, connection: Connection): Promise<string> {
+  const extensions = await getConnectionInfo(dbAccess, connection.id, 'extensions');
   return `Extensions: ${JSON.stringify(extensions)}`;
 }
 

--- a/apps/dbagent/src/lib/tools/logs.ts
+++ b/apps/dbagent/src/lib/tools/logs.ts
@@ -13,11 +13,8 @@ type GetInstanceLogsParams = {
 
 export async function getInstanceLogsRDS(
   dbAccess: DBAccess,
-  {
-    connection,
-    periodInSeconds,
-    grep,
-  }: GetInstanceLogsParams): Promise<string> {
+  { connection, periodInSeconds, grep }: GetInstanceLogsParams
+): Promise<string> {
   // Get AWS credentials from integrations
   const awsCredentials = await getIntegration(dbAccess, connection.projectId, 'aws');
   if (!awsCredentials) {
@@ -73,11 +70,8 @@ export async function getInstanceLogsRDS(
 
 export async function getInstanceLogsGCP(
   dbAccess: DBAccess,
-  {
-    connection,
-    periodInSeconds,
-    grep,
-  }: GetInstanceLogsParams): Promise<string> {
+  { connection, periodInSeconds, grep }: GetInstanceLogsParams
+): Promise<string> {
   const gcpCredentials = await getIntegration(dbAccess, connection.projectId, 'gcp');
   if (!gcpCredentials) {
     return 'GCP credentials not configured';

--- a/apps/dbagent/src/lib/tools/metrics.ts
+++ b/apps/dbagent/src/lib/tools/metrics.ts
@@ -1,8 +1,8 @@
 import { getRDSClusterMetric, getRDSInstanceMetric } from '../aws/rds';
 import { getClusterByConnection } from '../db/aws-clusters';
 import { Connection } from '../db/connections';
-import { getInstanceByConnection } from '../db/gcp-instances';
 import { DBAccess } from '../db/db';
+import { getInstanceByConnection } from '../db/gcp-instances';
 import { getIntegration } from '../db/integrations';
 import { getCloudSQLInstanceMetric, initializeMonitoringClient } from '../gcp/cloudsql';
 


### PR DESCRIPTION
So far we used `queryDB` to access the local database to store user and project data. `queryDB` uses NextAuth to fetch the userID and properly sets some SQL session variables to access RLS secured tables.

This PR attempts to reduce coupling between AI tools and NextAuth, so tools can be reused more easily. For example [Mastra Playground](https://github.com/xataio/agent/pull/56/files#diff-7c2b7278350052247bbb2cd941d691afb7b8006ff72abcc2095377c3066b8585)).

I removed queryDB and introduce a DBAccess interface. An instance is passed to the tools, which gives the tools access to the local database via `dbaccess.query(async (db) => ...)`.
By removing queryDB we also do not pass asAdmin or asUserId to functions accessing the DB. Instead the db access instance is properly instantiated with the given context. This context can not be changed by down stream functions (on purpose or by accident).

In some cases pages and components used to call functions that access the DB directly. Because we need a database access context to be established before we can access the DB I introduced actions that are used by the components instead.

Chat and normal UI operations establish a user session db access context, which uses NextAuth to fetch the user ID, as has been the case with queryDB.

The schedule runner uses `getAdminAccess()` to query all schedules, but finally creates a per schedule DB access context with the schedules user ID. This is replacing us passing `schedule.userID` along.