### PR TITLE
Model Provider registry

### DIFF
--- a/apps/dbagent/package.json
+++ b/apps/dbagent/package.json
@@ -21,6 +21,7 @@
     "@ai-sdk/deepseek": "^0.2.8",
     "@ai-sdk/google": "^1.2.10",
     "@ai-sdk/openai": "^1.3.9",
+    "@ai-sdk/provider": "^1.1.2",
     "@ai-sdk/react": "^1.2.8",
     "@ai-sdk/ui-utils": "^1.2.7",
     "@aws-sdk/client-cloudwatch": "^3.782.0",

--- a/apps/dbagent/src/components/chats/actions.ts
+++ b/apps/dbagent/src/components/chats/actions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { getDefaultLanguageModel, listLanguageModels } from '~/lib/ai/providers';
 import { getUserSessionDBAccess } from '~/lib/db/db';
 import { getScheduleRun } from '~/lib/db/schedule-runs';
 import { getSchedule } from '~/lib/db/schedules';
@@ -15,4 +16,12 @@ export async function actionGetScheduleRun(runId?: string) {
   } catch (error) {
     return null;
   }
+}
+
+export async function actionGetLanguageModels() {
+  return listLanguageModels().map((m) => m.info());
+}
+
+export async function actionGetDefaultLanguageModel() {
+  return getDefaultLanguageModel().info();
 }

--- a/apps/dbagent/src/components/chats/chats-ui.tsx
+++ b/apps/dbagent/src/components/chats/chats-ui.tsx
@@ -19,9 +19,11 @@ import { useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Bot } from '~/components/icons/bot';
+import { ModelInfo } from '~/lib/ai/providers/types';
 import { Connection } from '~/lib/db/connections';
 import { ScheduleRun } from '~/lib/db/schedule-runs';
 import { Schedule } from '~/lib/db/schedules';
+import { actionGetDefaultLanguageModel } from './actions';
 import { ChatSidebar } from './chat-sidebar';
 import { ConnectionSelector } from './conn-selector';
 import { mockChats } from './mock-data';
@@ -55,7 +57,8 @@ function ChatsUIContent({
   const [connectionId, setConnectionId] = useState<string>(
     scheduleRun?.schedule.connectionId || defaultConnection?.id || ''
   );
-  const [model, setModel] = useState(scheduleRun?.schedule.model || 'openai-gpt-4o');
+  const [defaultModel, setDefaultModel] = useState<ModelInfo>();
+  const [model, setModel] = useState(scheduleRun?.schedule.model || defaultModel?.id || '');
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const { messages, input, handleInputChange, handleSubmit, setInput, status, setMessages } = useChat({
@@ -65,6 +68,20 @@ function ChatsUIContent({
     },
     initialMessages: scheduleRun?.run.messages
   });
+
+  useEffect(() => {
+    async function loadModels() {
+      const defaultModelInfo = await actionGetDefaultLanguageModel();
+      setDefaultModel(defaultModelInfo);
+      console.log('defaultModelInfo', defaultModelInfo);
+    }
+    void loadModels();
+  }, []);
+  useEffect(() => {
+    if (defaultModel) {
+      setModel(defaultModel.id);
+    }
+  }, [defaultModel]);
 
   useEffect(() => {
     const startParam = searchParams.get('start');
@@ -109,7 +126,7 @@ function ChatsUIContent({
 
   /*useEffect(() => {
     const fetchScheduleRun = async (runId: string) => {
-      const { schedule, run } = await actionGetScheduleRun(runId)      
+      const { schedule, run } = await actionGetScheduleRun(runId)
       const newChat = {
         id: `new-${Date.now()}`,
         title: `Scheduled run followup`,

--- a/apps/dbagent/src/components/chats/model-selector.tsx
+++ b/apps/dbagent/src/components/chats/model-selector.tsx
@@ -1,4 +1,7 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@internal/components';
+import { useEffect, useState } from 'react';
+import { ModelInfo } from '~/lib/ai/providers/types';
+import { actionGetLanguageModels } from './actions';
 
 interface ModelSelectorProps {
   value: string;
@@ -6,18 +9,27 @@ interface ModelSelectorProps {
 }
 
 export function ModelSelector({ value, onValueChange }: ModelSelectorProps) {
+  const [models, setModels] = useState<ModelInfo[]>([]);
+
+  useEffect(() => {
+    async function loadModels() {
+      const models = await actionGetLanguageModels();
+      setModels(models);
+    }
+    void loadModels();
+  }, []);
+
   return (
     <Select value={value} onValueChange={onValueChange}>
       <SelectTrigger className="w-[180px]">
         <SelectValue placeholder="Select model" />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="openai-gpt-4o">GPT-4o</SelectItem>
-        <SelectItem value="openai-gpt-4-turbo">GPT-4 Turbo</SelectItem>
-        <SelectItem value="deepseek-chat">DeepSeek Chat</SelectItem>
-        <SelectItem value="anthropic-claude-3-7-sonnet-20250219">Claude 3.7 Sonnet</SelectItem>
-        <SelectItem value="gemini-2.0-flash">Gemini 2.0 Flash</SelectItem>
-        <SelectItem value="gemini-2.0-flash-lite">Gemini 2.0 Flash Lite</SelectItem>
+        {models.map((model) => (
+          <SelectItem key={model.id} value={model.id}>
+            {model.name}
+          </SelectItem>
+        ))}
       </SelectContent>
     </Select>
   );

--- a/apps/dbagent/src/lib/ai/aidba.ts
+++ b/apps/dbagent/src/lib/ai/aidba.ts
@@ -67,7 +67,7 @@ export async function getTools(
   return mergeToolsets(commonToolset, playbookToolset, dbTools, clusterTools);
 }
 
-export function getModelInstance(model_name: string): LanguageModel {
-  const model = getLanguageModel(model_name);
+export function getModelInstance(name: string): LanguageModel {
+  const model = getLanguageModel(name);
   return model.instance();
 }

--- a/apps/dbagent/src/lib/ai/aidba.ts
+++ b/apps/dbagent/src/lib/ai/aidba.ts
@@ -1,12 +1,9 @@
-import { anthropic } from '@ai-sdk/anthropic';
-import { deepseek } from '@ai-sdk/deepseek';
-import { google } from '@ai-sdk/google';
-import { openai } from '@ai-sdk/openai';
-import { LanguageModelV1, Tool } from 'ai';
+import { LanguageModel, Tool } from 'ai';
 import { Pool } from 'pg';
 import { Connection } from '~/lib/db/connections';
 import { getUserDBAccess } from '~/lib/db/db';
 import { Project } from '../db/projects';
+import { getLanguageModel } from './providers';
 import { commonToolset, getDBClusterTools, getDBSQLTools, getPlaybookToolset, mergeToolsets } from './tools';
 
 const commonSystemPrompt = `
@@ -70,16 +67,7 @@ export async function getTools(
   return mergeToolsets(commonToolset, playbookToolset, dbTools, clusterTools);
 }
 
-export function getModelInstance(model: string): LanguageModelV1 {
-  if (model.startsWith('openai-')) {
-    return openai(model.replace('openai-', ''));
-  } else if (model.startsWith('deepseek-')) {
-    return deepseek(model);
-  } else if (model.startsWith('anthropic-')) {
-    return anthropic(model.replace('anthropic-', ''));
-  } else if (model.startsWith('gemini-')) {
-    return google(model);
-  } else {
-    throw new Error('Invalid model');
-  }
+export function getModelInstance(model_name: string): LanguageModel {
+  const model = getLanguageModel(model_name);
+  return model.instance();
 }

--- a/apps/dbagent/src/lib/ai/providers/builtin.ts
+++ b/apps/dbagent/src/lib/ai/providers/builtin.ts
@@ -28,10 +28,12 @@ type ProviderModel = {
 class BuiltinModel implements Model {
   #info: ModelInfo;
   #provider: ProviderV1;
+  #providerId: string;
 
-  constructor(provider: ProviderV1, info: ModelInfo) {
+  constructor(provider: ProviderV1, providerId: string, info: ModelInfo) {
     this.#info = info;
     this.#provider = provider;
+    this.#providerId = providerId;
   }
 
   info(): ModelInfo {
@@ -39,7 +41,7 @@ class BuiltinModel implements Model {
   }
 
   instance(): LanguageModel {
-    return this.#provider.languageModel(this.#info.id);
+    return this.#provider.languageModel(this.#providerId);
   }
 }
 
@@ -112,11 +114,11 @@ const builtinGoogleModels: Provider = {
 const builtinProviderModels: Record<string, BuiltinModel> = Object.fromEntries(
   [builtinOpenAIModels, builtinDeepseekModels, builtinAnthropicModels, builtinGoogleModels].flatMap((p) => {
     return p.models.map((m) => {
-      const fullId = `${p.info.id}-${m.providerId || m.id}`;
+      const fullId = `${p.info.id}-${m.id}`;
       return [
         fullId,
-        new BuiltinModel(p.info.kind, {
-          id: m.id,
+        new BuiltinModel(p.info.kind, m.providerId || m.id, {
+          id: fullId,
           name: m.name
         })
       ];

--- a/apps/dbagent/src/lib/ai/providers/builtin.ts
+++ b/apps/dbagent/src/lib/ai/providers/builtin.ts
@@ -116,7 +116,7 @@ const builtinProviderModels: Record<string, BuiltinModel> = Object.fromEntries(
       return [
         fullId,
         new BuiltinModel(p.info.kind, {
-          id: fullId,
+          id: m.id,
           name: m.name
         })
       ];

--- a/apps/dbagent/src/lib/ai/providers/builtin.ts
+++ b/apps/dbagent/src/lib/ai/providers/builtin.ts
@@ -1,0 +1,162 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { deepseek } from '@ai-sdk/deepseek';
+import { google } from '@ai-sdk/google';
+import { openai } from '@ai-sdk/openai';
+import { ProviderV1 } from '@ai-sdk/provider';
+import { LanguageModel } from 'ai';
+
+import { Model, ModelInfo, ProviderRegistry } from './types';
+
+type Provider = {
+  info: ProviderInfo;
+  models: ProviderModel[];
+};
+
+type ProviderInfo = {
+  name: string;
+  id: string;
+  kind: ProviderV1;
+  fallback?: string;
+};
+
+type ProviderModel = {
+  id: string;
+  providerId?: string;
+  name: string;
+};
+
+class BuiltinModel implements Model {
+  #info: ModelInfo;
+  #provider: ProviderV1;
+
+  constructor(provider: ProviderV1, info: ModelInfo) {
+    this.#info = info;
+    this.#provider = provider;
+  }
+
+  info(): ModelInfo {
+    return this.#info;
+  }
+
+  instance(): LanguageModel {
+    return this.#provider.languageModel(this.#info.id);
+  }
+}
+
+const builtinOpenAIModels: Provider = {
+  info: {
+    name: 'OpenAI',
+    id: 'openai',
+    kind: openai,
+    fallback: 'gpt-4o'
+  },
+  models: [
+    {
+      id: 'gpt-4o',
+      name: 'GPT-4o'
+    },
+    {
+      id: 'gpt-4-turbo',
+      name: 'GPT-4 Turbo'
+    }
+  ]
+};
+
+const builtinDeepseekModels: Provider = {
+  info: {
+    name: 'DeepSeek',
+    id: 'deepseek',
+    kind: deepseek
+  },
+  models: [
+    {
+      id: 'deepseek-chat',
+      name: 'DeepSeek Chat'
+    }
+  ]
+};
+
+const builtinAnthropicModels: Provider = {
+  info: {
+    name: 'Anthropic',
+    id: 'anthropic',
+    kind: anthropic
+  },
+  models: [
+    {
+      id: 'claude-3-7-sonnet',
+      providerId: 'claude-3-7-sonnet-20250219',
+      name: 'Claude 3.7 Sonnet'
+    }
+  ]
+};
+
+const builtinGoogleModels: Provider = {
+  info: {
+    name: 'Google',
+    id: 'google',
+    kind: google
+  },
+  models: [
+    {
+      id: 'gemini-2.0-flash',
+      name: 'Gemini 2.0 Flash'
+    },
+    {
+      id: 'gemini-2.0-flash-lite',
+      name: 'Gemini 2.0 Flash Lite'
+    }
+  ]
+};
+
+const builtinProviderModels: Record<string, BuiltinModel> = Object.fromEntries(
+  [builtinOpenAIModels, builtinDeepseekModels, builtinAnthropicModels, builtinGoogleModels].flatMap((p) => {
+    return p.models.map((m) => {
+      const fullId = `${p.info.id}-${m.providerId || m.id}`;
+      return [
+        fullId,
+        new BuiltinModel(p.info.kind, {
+          id: fullId,
+          name: m.name
+        })
+      ];
+    });
+  })
+);
+
+export const defaultLanguageModel = builtinProviderModels['openai-gpt-4o']!;
+
+const builtinCustomModels: Record<string, BuiltinModel> = {
+  chat: defaultLanguageModel,
+  title: defaultLanguageModel,
+  summary: defaultLanguageModel
+};
+
+const builtinModels: Record<string, BuiltinModel> = {
+  ...builtinProviderModels,
+  ...builtinCustomModels
+};
+
+class BuiltinProviderRegistry implements ProviderRegistry {
+  listLanguageModels(): Model[] {
+    return Object.values(builtinProviderModels);
+  }
+
+  defaultLanguageModel(): Model {
+    return defaultLanguageModel;
+  }
+
+  languageModel(id: string): Model {
+    const model = builtinModels[id];
+    if (!model) {
+      throw new Error(`Model ${id} not found`);
+    }
+    return model;
+  }
+}
+
+const builtinProviderRegistry = new BuiltinProviderRegistry();
+
+export function getBuiltinProviderRegistry(): ProviderRegistry {
+  return builtinProviderRegistry;
+}

--- a/apps/dbagent/src/lib/ai/providers/index.ts
+++ b/apps/dbagent/src/lib/ai/providers/index.ts
@@ -1,0 +1,24 @@
+export * from './builtin';
+export * from './types';
+
+import { getBuiltinProviderRegistry } from './builtin';
+import { Model, ProviderRegistry } from './types';
+
+export function getProviderRegistry(): ProviderRegistry {
+  return getBuiltinProviderRegistry();
+}
+
+export function listLanguageModels(): Model[] {
+  const registry = getProviderRegistry();
+  return registry.listLanguageModels();
+}
+
+export function getDefaultLanguageModel(): Model {
+  const registry = getProviderRegistry();
+  return registry.defaultLanguageModel();
+}
+
+export function getLanguageModel(modelId: string): Model {
+  const registry = getProviderRegistry();
+  return registry.languageModel(modelId);
+}

--- a/apps/dbagent/src/lib/ai/providers/types.ts
+++ b/apps/dbagent/src/lib/ai/providers/types.ts
@@ -1,0 +1,18 @@
+import { LanguageModel } from 'ai';
+
+export interface ProviderRegistry {
+  listLanguageModels(): Model[];
+  defaultLanguageModel(): Model;
+  languageModel(modelId: string): Model;
+}
+
+export interface Model {
+  info(): ModelInfo;
+
+  instance(): LanguageModel;
+}
+
+export type ModelInfo = {
+  name: string;
+  id: string;
+};

--- a/apps/dbagent/src/lib/ai/providers/types.ts
+++ b/apps/dbagent/src/lib/ai/providers/types.ts
@@ -7,12 +7,14 @@ export interface ProviderRegistry {
 }
 
 export interface Model {
+  fullId(): string;
+
   info(): ModelInfo;
 
   instance(): LanguageModel;
 }
 
 export type ModelInfo = {
-  name: string;
   id: string;
+  name: string;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^1.3.9
         version: 1.3.9(zod@3.24.2)
+      '@ai-sdk/provider':
+        specifier: ^1.1.2
+        version: 1.1.2
       '@ai-sdk/react':
         specifier: ^1.2.8
         version: 1.2.8(react@19.1.0)(zod@3.24.2)


### PR DESCRIPTION
Backport from #63 introducing a ProviderRegistry interface
The code does not reuse the provider registry from ai-sdk, because we want to allow the code to inspect available models before creating an instance.