### PR TITLE
Fix getting instance logs for RDS

### DIFF
--- a/apps/dbagent/src/lib/tools/logs.ts
+++ b/apps/dbagent/src/lib/tools/logs.ts
@@ -24,6 +24,7 @@ export async function getInstanceLogsRDS(
 
   const cluster = await getClusterByConnection(dbAccess, connection.id);
   if (!cluster) {
+    console.log('Cluster not found for connection:', connection.id);
     return 'Cluster not found';
   }
 


### PR DESCRIPTION
Should fix #75.

Main issue was that we didn't select the writer instance correctly, but also there was a problem with splitting the logs into lines before filtering.