### PR TITLE
Get metrics from the writer instance, instead of the whole AWS cluster

### DIFF
--- a/apps/dbagent/src/lib/ai/tools/cluster.ts
+++ b/apps/dbagent/src/lib/ai/tools/cluster.ts
@@ -105,15 +105,17 @@ export class AWSDBClusterTools implements ToolsetGroup {
     const getter = this.#getter;
     const db = this.#dbAccess;
     return tool({
-      description: `Get the metrics for the RDS instance. You can specify the period in seconds.`,
+      description: `Get the metrics for the RDS instance. If this is a cluster, the metric is read from the current writer instance.
+      You can specify the period in seconds. The stat parameter is one of the following: Average, Maximum, Minimum, Sum. It defaults to Average.`,
       parameters: z.object({
         metricName: z.string(),
-        periodInSeconds: z.number()
+        periodInSeconds: z.number(),
+        stat: z.enum(['Average', 'Maximum', 'Minimum', 'Sum']).optional()
       }),
-      execute: async ({ metricName, periodInSeconds }) => {
+      execute: async ({ metricName, periodInSeconds, stat }) => {
         console.log('getClusterMetric', metricName, periodInSeconds);
         const connection = await getter();
-        return await getClusterMetricRDS(db, { connection, metricName, periodInSeconds });
+        return await getClusterMetricRDS(db, { connection, metricName, periodInSeconds, stat });
       }
     });
   }

--- a/apps/dbagent/src/lib/tools/metrics.ts
+++ b/apps/dbagent/src/lib/tools/metrics.ts
@@ -11,7 +11,7 @@ type GetClusterMetricParams = {
   cloudProvider: CloudProvider;
   metricName: string;
   periodInSeconds: number;
-  stat: 'Average' | 'Maximum' | 'Minimum' | 'Sum' | undefined;
+  stat?: 'Average' | 'Maximum' | 'Minimum' | 'Sum';
 };
 
 export async function getClusterMetricRDS(

--- a/apps/dbagent/src/lib/tools/metrics.ts
+++ b/apps/dbagent/src/lib/tools/metrics.ts
@@ -11,11 +11,12 @@ type GetClusterMetricParams = {
   cloudProvider: CloudProvider;
   metricName: string;
   periodInSeconds: number;
+  stat: 'Average' | 'Maximum' | 'Minimum' | 'Sum' | undefined;
 };
 
 export async function getClusterMetricRDS(
   dbAccess: DBAccess,
-  { connection, metricName, periodInSeconds }: Omit<GetClusterMetricParams, 'cloudProvider'>
+  { connection, metricName, periodInSeconds, stat }: Omit<GetClusterMetricParams, 'cloudProvider'>
 ): Promise<string> {
   const awsCredentials = await getIntegration(dbAccess, connection.projectId, 'aws');
   if (!awsCredentials) {
@@ -39,7 +40,8 @@ export async function getClusterMetricRDS(
         awsCredentials,
         metricName,
         startTime,
-        endTime
+        endTime,
+        stat
       );
     } else {
       datapoints = await getRDSInstanceMetric(
@@ -48,7 +50,8 @@ export async function getClusterMetricRDS(
         awsCredentials,
         metricName,
         startTime,
-        endTime
+        endTime,
+        stat
       );
     }
     const toReturn = datapoints


### PR DESCRIPTION
This makes it consistent with what we do for logs. Also added the ability for the agent to select the min/max/average/sum component. 

Fixes #76.

<img width="768" alt="Screenshot 2025-04-15 at 11 06 56" src="https://github.com/user-attachments/assets/09fb69e3-3c51-4623-a098-62d168959c04" />

