### PR TITLE
Protect against really long queries

### DIFF
--- a/apps/dbagent/src/lib/tools/slow-queries.ts
+++ b/apps/dbagent/src/lib/tools/slow-queries.ts
@@ -2,9 +2,21 @@ import { ClientBase, describeTable, explainQuery, getSlowQueries } from '../targ
 
 export async function toolGetSlowQueries(client: ClientBase, thresholdMs: number): Promise<string> {
   const slowQueries = await getSlowQueries(client, thresholdMs);
-  const result = JSON.stringify(slowQueries);
+  // Filter out slow queries with query text larger than 5k characters
+  const filteredSlowQueries = slowQueries.map((query) => {
+    if (query.query && query.query.length > 5000) {
+      return {
+        ...query,
+        query: 'Err: query too long to analyze'
+      };
+    }
+    return query;
+  });
+
+  const result = JSON.stringify(filteredSlowQueries);
   console.log(result);
-  return JSON.stringify(slowQueries);
+
+  return JSON.stringify(filteredSlowQueries);
 }
 
 export async function toolExplainQuery(client: ClientBase, schema: string, query: string): Promise<string> {


### PR DESCRIPTION
Really long queries can exceed the context window and break the run.

Add a hardcoded limit of 5k for now, partially fixing #116.