### PR TITLE
Providers improvements

### DIFF
--- a/apps/dbagent/src/lib/ai/providers/builtin.ts
+++ b/apps/dbagent/src/lib/ai/providers/builtin.ts
@@ -2,9 +2,10 @@ import { anthropic } from '@ai-sdk/anthropic';
 import { deepseek } from '@ai-sdk/deepseek';
 import { google } from '@ai-sdk/google';
 import { openai } from '@ai-sdk/openai';
-import { LanguageModel } from 'ai';
+import { env } from '~/lib/env/server';
 
-import { Model, ModelWithFallback, Provider, ProviderInfo, ProviderModel, ProviderRegistry } from './types';
+import { Model, Provider, ProviderModel, ProviderRegistry } from './types';
+import { createModel, createRegistryFromModels } from './utils';
 
 type BuiltinProvider = Provider & {
   models: BuiltinProviderModel[];
@@ -13,25 +14,6 @@ type BuiltinProvider = Provider & {
 type BuiltinProviderModel = ProviderModel & {
   providerId: string;
 };
-
-class BuiltinModel implements Model {
-  #model: BuiltinProviderModel;
-  #provider: ProviderInfo;
-
-  constructor(provider: ProviderInfo, model: BuiltinProviderModel) {
-    this.#model = model;
-    this.#provider = provider;
-  }
-
-  info(): BuiltinProviderModel {
-    return this.#model;
-  }
-
-  instance(): LanguageModel {
-    const model = this.info();
-    return this.#provider.kind.languageModel(model.providerId);
-  }
-}
 
 const builtinOpenAIModels: BuiltinProvider = {
   info: {
@@ -124,52 +106,50 @@ const builtinGoogleModels: BuiltinProvider = {
   ]
 };
 
-const builtinProviderModels: Record<string, BuiltinModel> = Object.fromEntries(
-  [builtinOpenAIModels, builtinDeepseekModels, builtinAnthropicModels, builtinGoogleModels].flatMap((p) => {
-    return p.models.map((model) => {
-      const modelInstance = new BuiltinModel(p.info, model as BuiltinProviderModel);
-      return [modelInstance.info().id, modelInstance];
-    });
-  })
-);
+const builtinProviderModels: Record<string, Model> = (function () {
+  const activeList: BuiltinProvider[] = [];
+  if (env.OPENAI_API_KEY) {
+    activeList.push(builtinOpenAIModels);
+  }
+  if (env.DEEPSEEK_API_KEY) {
+    activeList.push(builtinDeepseekModels);
+  }
+  if (env.ANTHROPIC_API_KEY) {
+    activeList.push(builtinAnthropicModels);
+  }
+  if (env.GOOGLE_GENERATIVE_AI_API_KEY) {
+    activeList.push(builtinGoogleModels);
+  }
 
-export const defaultLanguageModel = builtinProviderModels['openai:gpt-4.1']!;
+  if (activeList.length === 0) {
+    throw new Error('No providers enabled. Please configure API keys');
+  }
+  return Object.fromEntries(
+    activeList.flatMap((p) => {
+      const factory = p.info.kind;
+      return p.models.map((model: BuiltinProviderModel) => {
+        const modelInstance = createModel(model, () => factory.languageModel(model.providerId));
+        return [modelInstance.info().id, modelInstance];
+      });
+    })
+  );
+})();
 
-const builtinCustomModels: Record<string, BuiltinModel> = {
-  chat: defaultLanguageModel,
-  title: builtinProviderModels['openai:gpt-4.1-mini']!,
-  summary: builtinProviderModels['openai:gpt-4.1-mini']!
+const defaultLanguageModel = builtinProviderModels['openai:gpt-4.1'] ?? Object.values(builtinProviderModels)[0]!;
+const defaultTitleModel = builtinProviderModels['openai:gpt-4.1-mini'] ?? Object.values(builtinProviderModels)[0]!;
+const defaultSummaryModel = builtinProviderModels['openai:gpt-4.1-mini'] ?? Object.values(builtinProviderModels)[0]!;
+
+const builtinModelAliases: Record<string, string> = {
+  chat: defaultLanguageModel.info().id,
+  title: defaultTitleModel.info().id,
+  summary: defaultSummaryModel.info().id
 };
 
-const builtinModels: Record<string, BuiltinModel> = {
-  ...builtinProviderModels,
-  ...builtinCustomModels
-};
-
-class BuiltinProviderRegistry implements ProviderRegistry {
-  listLanguageModels(): Model[] {
-    return Object.values(builtinProviderModels);
-  }
-
-  defaultLanguageModel(): Model {
-    return defaultLanguageModel;
-  }
-
-  languageModel(id: string, useFallback?: boolean): ModelWithFallback {
-    const model = builtinModels[id];
-    if (!model) {
-      throw new Error(`Model ${id} not found`);
-    }
-    return {
-      info: () => model.info(),
-      instance: () => model.instance(),
-      isFallback: useFallback ?? false,
-      requestedModelId: id
-    } as ModelWithFallback;
-  }
-}
-
-const builtinProviderRegistry = new BuiltinProviderRegistry();
+const builtinProviderRegistry = createRegistryFromModels({
+  models: builtinProviderModels,
+  aliases: builtinModelAliases,
+  defaultModel: defaultLanguageModel
+});
 
 export function getBuiltinProviderRegistry(): ProviderRegistry {
   return builtinProviderRegistry;

--- a/apps/dbagent/src/lib/ai/providers/index.ts
+++ b/apps/dbagent/src/lib/ai/providers/index.ts
@@ -6,25 +6,29 @@ import { env } from '~/lib/env/server';
 import { getBuiltinProviderRegistry } from './builtin';
 import { createLiteLLMProviderRegistry } from './litellm';
 import { Model, ModelWithFallback, ProviderRegistry } from './types';
+import { cached } from './utils';
 
-let cachedRegistry: ProviderRegistry | null = null;
-let lastCacheTime: number | null = null;
 const CACHE_TTL_MS = 60 * 1000; // 1 minute
 
-export async function getProviderRegistry(): Promise<ProviderRegistry> {
+function buildProviderRegistry() {
   if (env.LITELLM_BASE_URL && env.LITELLM_API_KEY) {
-    const now = Date.now();
-    if (!cachedRegistry || !lastCacheTime || now - lastCacheTime > CACHE_TTL_MS) {
-      cachedRegistry = await createLiteLLMProviderRegistry({
-        baseUrl: env.LITELLM_BASE_URL,
-        token: env.LITELLM_API_KEY
-      });
-      lastCacheTime = now;
-    }
-  } else if (!cachedRegistry) {
-    cachedRegistry = getBuiltinProviderRegistry();
+    return cached(
+      CACHE_TTL_MS,
+      async () =>
+        await createLiteLLMProviderRegistry({
+          baseUrl: env.LITELLM_BASE_URL!,
+          token: env.LITELLM_API_KEY!
+        })
+    );
   }
-  return cachedRegistry;
+
+  return () => Promise.resolve(getBuiltinProviderRegistry());
+}
+
+const providerRegistry: () => Promise<ProviderRegistry> = buildProviderRegistry();
+
+export async function getProviderRegistry(): Promise<ProviderRegistry> {
+  return await providerRegistry();
 }
 
 export async function listLanguageModels(): Promise<Model[]> {
@@ -34,7 +38,11 @@ export async function listLanguageModels(): Promise<Model[]> {
 
 export async function getDefaultLanguageModel(): Promise<Model> {
   const registry = await getProviderRegistry();
-  return registry.defaultLanguageModel();
+  const model = registry.defaultLanguageModel();
+  if (!model) {
+    throw new Error('No default language model configured');
+  }
+  return model;
 }
 
 export async function getLanguageModel(modelId: string): Promise<Model> {

--- a/apps/dbagent/src/lib/ai/providers/types.ts
+++ b/apps/dbagent/src/lib/ai/providers/types.ts
@@ -3,7 +3,7 @@ import { LanguageModel } from 'ai';
 
 export interface ProviderRegistry {
   listLanguageModels(): Model[];
-  defaultLanguageModel(): Model;
+  defaultLanguageModel(): Model | null;
   languageModel(modelId: string, useFallback?: boolean): ModelWithFallback;
 }
 

--- a/apps/dbagent/src/lib/ai/providers/utils.ts
+++ b/apps/dbagent/src/lib/ai/providers/utils.ts
@@ -1,0 +1,93 @@
+import { LanguageModel } from 'ai';
+import { Model, ModelWithFallback, ProviderModel, ProviderRegistry } from './types';
+
+type RegistryFromModelsProps<TModel extends Model> = {
+  models: TModel[] | Record<string, TModel>;
+  aliases?: Record<string, string>;
+  id?: (model: TModel) => string;
+  defaultModel?: TModel | null;
+  fallback?: (modelId: string) => TModel | undefined;
+};
+
+export function createRegistryFromModels<TModel extends Model>({
+  models,
+  id,
+  defaultModel,
+  fallback,
+  aliases
+}: RegistryFromModelsProps<TModel>): ProviderRegistry {
+  const index: Record<string, TModel> = Array.isArray(models)
+    ? Object.fromEntries(models.map((m: TModel) => [id ? id(m) : m.info().id, m]))
+    : models;
+  const useDefault: TModel | null = defaultModel ?? (Array.isArray(models) ? models[0]! : Object.values(models)[0]!);
+  const aliasModels: Record<string, TModel> = aliases
+    ? Object.fromEntries(Object.entries(aliases).map(([alias, modelId]) => [alias, index[modelId]!]))
+    : {};
+
+  return {
+    listLanguageModels: () => Object.values(index),
+    defaultLanguageModel: () => useDefault,
+    languageModel: (modelId: string, useFallback?: boolean) => {
+      const withFallback = useFallback && !!fallback;
+
+      const model = index[modelId] ?? aliasModels[modelId];
+      if (!model && !withFallback) {
+        throw new Error(`Model ${modelId} not found`);
+      }
+      if (model) {
+        return reportOriginalModel(model);
+      }
+
+      const fallbackModel = fallback?.(modelId);
+      if (!fallbackModel) {
+        throw new Error(`Model ${modelId} not found and no fallback available`);
+      }
+      return reportFallbackModel(modelId, fallbackModel);
+    }
+  };
+}
+
+export function createModel<TProviderModel extends ProviderModel, TLanguageModel extends LanguageModel>(
+  info: TProviderModel,
+  instance: () => TLanguageModel
+): Model {
+  return {
+    info: () => info,
+    instance: () => instance()
+  } as Model;
+}
+
+export function reportOriginalModel<TModel extends Model>(model: TModel): ModelWithFallback {
+  return {
+    info: () => model.info(),
+    instance: () => model.instance(),
+    isFallback: false,
+    requestedModelId: model.info().id
+  } as ModelWithFallback;
+}
+
+export function reportFallbackModel<TModel extends Model>(modelId: string, fallback: TModel): ModelWithFallback {
+  return {
+    info: () => fallback.info(),
+    instance: () => fallback.instance(),
+    isFallback: true,
+    requestedModelId: modelId
+  } as ModelWithFallback;
+}
+
+export function cached<T>(ttlMs: number, fn: () => Promise<T>): () => Promise<T> {
+  let value: T | null = null;
+  let lastUpdate: number | null = null;
+
+  return async () => {
+    const now = Date.now();
+    if (lastUpdate && now - lastUpdate < ttlMs) {
+      return value!;
+    }
+
+    const result = await fn();
+    value = result;
+    lastUpdate = now;
+    return result;
+  };
+}


### PR DESCRIPTION
Some providers improvements backported from #136 

Builtin providers will only include models for providers whose API key was provided.

Introduce `createRegistryFromModels` and `createModel` to provide a common provider registry implementation. Most of the BuiltinX and LiteLLMX classes have been removed.
These functions make it easier to create provider registries. For example Ollama is just a few lines: https://github.com/xataio/agent/blob/b651f767d4d079403248b923ac885cacb9a367f4/apps/dbagent/src/lib/ai/providers/ollama.ts