### PR TITLE
Add reasoning models O1 and O4-mini

### DIFF
--- a/apps/dbagent/src/lib/ai/providers/builtin.ts
+++ b/apps/dbagent/src/lib/ai/providers/builtin.ts
@@ -42,6 +42,16 @@ const builtinOpenAIModels: BuiltinProvider = {
       id: 'openai:gpt-4-turbo',
       providerId: 'gpt-4-turbo',
       name: 'GPT-4 Turbo'
+    },
+    {
+      id: 'openai:o4-mini',
+      providerId: 'o4-mini',
+      name: 'OpenAI o4-mini'
+    },
+    {
+      id: 'openai:o1',
+      providerId: 'o1',
+      name: 'OpenAI o1'
     }
   ]
 };

--- a/apps/dbagent/src/lib/ai/tools/cluster.ts
+++ b/apps/dbagent/src/lib/ai/tools/cluster.ts
@@ -88,10 +88,11 @@ export class AWSDBClusterTools implements ToolsetGroup {
     const getter = this.#getter;
     const db = this.#dbAccess;
     return tool({
-      description: `Get the recent logs from the RDS instance. You can specify the period in seconds and optionally grep for a substring.`,
+      description: `Get the recent logs from the RDS instance. You can specify the period in seconds and optionally grep for a substring. 
+      If you don't want to grep for a substring, you can pass an empty string.`,
       parameters: z.object({
         periodInSeconds: z.number(),
-        grep: z.string().optional()
+        grep: z.string()
       }),
       execute: async ({ periodInSeconds, grep }) => {
         console.log('getInstanceLogs', periodInSeconds, grep);
@@ -106,11 +107,11 @@ export class AWSDBClusterTools implements ToolsetGroup {
     const db = this.#dbAccess;
     return tool({
       description: `Get the metrics for the RDS instance. If this is a cluster, the metric is read from the current writer instance.
-      You can specify the period in seconds. The stat parameter is one of the following: Average, Maximum, Minimum, Sum. It defaults to Average.`,
+      You can specify the period in seconds. The stat parameter is one of the following: Average, Maximum, Minimum, Sum.`,
       parameters: z.object({
         metricName: z.string(),
         periodInSeconds: z.number(),
-        stat: z.enum(['Average', 'Maximum', 'Minimum', 'Sum']).optional()
+        stat: z.enum(['Average', 'Maximum', 'Minimum', 'Sum'])
       }),
       execute: async ({ metricName, periodInSeconds, stat }) => {
         console.log('getClusterMetric', metricName, periodInSeconds);


### PR DESCRIPTION
It seems that the reasoning models don't support tools (functions in OpenAI lingo) with optional parameters. We only had two tools that were using optional parameters, and we didn't really need that, so for now I just made the parameters mandatory.

This just adds the models, but we'd want the UI to display the intermediary reasoning as well, which is not happening currently.