### PR TITLE
feat: Add support for remote MCP server types

### DIFF
--- a/apps/dbagent/migrations/0009_mcp_server_type_and_url.sql
+++ b/apps/dbagent/migrations/0009_mcp_server_type_and_url.sql
@@ -1,0 +1,12 @@
+-- Add mcp_server_type enum type if it doesn't exist
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mcp_server_type') THEN
+        CREATE TYPE mcp_server_type AS ENUM ('stdio', 'sse', 'streamable-http');
+    END IF;
+END$$;
+
+-- Add the new columns to the mcp_servers table
+ALTER TABLE mcp_servers
+ADD COLUMN type mcp_server_type DEFAULT 'stdio',
+ADD COLUMN url TEXT;

--- a/apps/dbagent/src/app/api/mcp/servers/[server]/route.ts
+++ b/apps/dbagent/src/app/api/mcp/servers/[server]/route.ts
@@ -1,42 +1,112 @@
-import { promises as fs } from 'fs';
 import { NextResponse } from 'next/server';
-import path from 'path';
-import { getMCPSourceDir } from '~/lib/ai/tools/user-mcp';
+import { z } from 'zod';
+import { dbAccess } from '~/lib/db/db'; // Assuming dbAccess is available
+import { getUserMcpServer, updateUserMcpServer, deleteUserMcpServer } from '~/lib/db/mcp-servers';
+import { MCPServerType } from '~/lib/db/schema'; // Import the enum type
 
-const mcpSourceDir = getMCPSourceDir();
+// Zod schema for updating an MCP Server (all fields optional)
+const mcpServerUpdateSchema = z.object({
+  serverName: z.string().min(1).optional(),
+  filePath: z.string().min(1).optional(),
+  version: z.string().min(1).optional(),
+  type: z.enum<MCPServerType, ['stdio', 'sse', 'streamable-http']>(['stdio', 'sse', 'streamable-http']).optional(),
+  url: z.string().url('Invalid URL format').nullable().optional(),
+  enabled: z.boolean().optional(),
+  envVars: z.record(z.string()).optional(),
+});
 
-export async function GET(_: Request, { params }: { params: Promise<{ server: string }> }) {
+export async function GET(_: Request, { params }: { params: { server: string } }) {
   try {
-    const { server } = await params;
-    const filePath = path.join(mcpSourceDir, `${server}.ts`);
-
-    // Check if file exists
-    try {
-      await fs.access(filePath);
-    } catch (error) {
-      return NextResponse.json({ error: 'Server file not found' }, { status: 404 });
+    const serverName = params.server; // This is the 'name' field of the server
+    if (!serverName) {
+      return NextResponse.json({ error: 'Server name parameter is missing' }, { status: 400 });
     }
 
-    // Read file content
-    const content = await fs.readFile(filePath, 'utf-8');
+    const server = await getUserMcpServer(dbAccess, serverName);
 
-    // Extract metadata from file content
-    const nameMatch = content.match(/name:\s*['"]([^'"]+)['"]/);
-    const versionMatch = content.match(/version:\s*['"]([^'"]+)['"]/);
-    const descriptionMatch = content.match(/description:\s*['"]([^'"]+)['"]/);
+    if (!server) {
+      return NextResponse.json({ error: 'Server not found' }, { status: 404 });
+    }
+    return NextResponse.json(server);
+  } catch (error) {
+    console.error('Error fetching MCP server:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+    return NextResponse.json({ error: 'Failed to fetch MCP server', details: errorMessage }, { status: 500 });
+  }
+}
 
-    const metadata = {
-      name: server,
-      serverName: nameMatch ? nameMatch[1] : server,
-      version: versionMatch ? versionMatch[1] : '1.0.0',
-      description: descriptionMatch ? descriptionMatch[1] : '',
-      filePath: `${server}.ts`,
-      enabled: false
+export async function PUT(request: Request, { params }: { params: { server: string } }) {
+  try {
+    const serverNameFromParams = params.server; // This is the 'name' field to identify the server
+    if (!serverNameFromParams) {
+      return NextResponse.json({ error: 'Server name parameter is missing' }, { status: 400 });
+    }
+
+    const body = await request.json();
+    const validatedData = mcpServerUpdateSchema.safeParse(body);
+
+    if (!validatedData.success) {
+      return NextResponse.json({ error: 'Invalid input', details: validatedData.error.flatten() }, { status: 400 });
+    }
+
+    const updatePayload = { ...validatedData.data };
+
+    // Logic for type and url:
+    // If type is explicitly set to 'stdio', url should be null.
+    if (updatePayload.type === 'stdio') {
+        updatePayload.url = null;
+    } else if ((updatePayload.type === 'sse' || updatePayload.type === 'streamable-http') && 
+               (updatePayload.url === undefined || updatePayload.url === null)) {
+      // If type is sse/streamable-http, URL is expected.
+      // Check if the existing record already has a URL if type is not in payload
+      if (updatePayload.type !== undefined) { // type is being explicitly set
+        return NextResponse.json({ error: `URL is required when type is '${updatePayload.type}'` }, { status: 400 });
+      }
+      // If type is not in payload, we might need to fetch the server to check its current type
+      // and see if the URL becomes implicitly required.
+      // For simplicity now, this check is only if 'type' is in the payload.
+    }
+
+
+    // The updateUserMcpServer function expects an MCPServerInsert-like object,
+    // where 'name' is the identifier for the WHERE clause.
+    const serverToUpdate = {
+      name: serverNameFromParams, // Critical: This is the key for the update operation
+      ...updatePayload
     };
 
-    return NextResponse.json(metadata);
+    const updatedServer = await updateUserMcpServer(dbAccess, serverToUpdate);
+    return NextResponse.json(updatedServer);
+
   } catch (error) {
-    console.error('Error reading server file:', error);
-    return NextResponse.json({ error: 'Failed to read server file' }, { status: 500 });
+    console.error('Error updating MCP server:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+     if (errorMessage.includes('not found or no values changed') || errorMessage.includes('not found or update failed')) {
+        return NextResponse.json({ error: errorMessage }, { status: 404 });
+    }
+    if (errorMessage.includes('already exists')) {
+        return NextResponse.json({ error: errorMessage }, { status: 409 }); // Conflict
+    }
+    return NextResponse.json({ error: 'Failed to update MCP server', details: errorMessage }, { status: 500 });
+  }
+}
+
+export async function DELETE(_: Request, { params }: { params: { server: string } }) {
+  try {
+    const serverName = params.server; // This is the 'name' field of the server
+    if (!serverName) {
+      return NextResponse.json({ error: 'Server name parameter is missing' }, { status: 400 });
+    }
+
+    await deleteUserMcpServer(dbAccess, serverName);
+    return NextResponse.json({ message: `Server "${serverName}" deleted successfully` }, { status: 200 }); // Or 204 No Content
+
+  } catch (error) {
+    console.error('Error deleting MCP server:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+    if (errorMessage.includes('not found')) {
+        return NextResponse.json({ error: errorMessage }, { status: 404 });
+    }
+    return NextResponse.json({ error: 'Failed to delete MCP server', details: errorMessage }, { status: 500 });
   }
 }

--- a/apps/dbagent/src/app/api/mcp/servers/route.ts
+++ b/apps/dbagent/src/app/api/mcp/servers/route.ts
@@ -1,37 +1,62 @@
-import { promises as fs } from 'fs';
 import { NextResponse } from 'next/server';
-import path from 'path';
-import { getMCPSourceDir } from '~/lib/ai/tools/user-mcp';
+import { z } from 'zod';
+import { addUserMcpServerToDB, getUserMcpServers } from '~/lib/db/mcp-servers';
+import { dbAccess } from '~/lib/db/db'; // Assuming dbAccess is available like this
+import { MCPServerType } from '~/lib/db/schema'; // Import the enum type for Zod
 
-const mcpSourceDir = getMCPSourceDir();
+// Zod schema for MCPServerInsert
+const mcpServerInsertSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  serverName: z.string().min(1, 'Server name is required'),
+  filePath: z.string().min(1, 'File path is required'),
+  version: z.string().min(1, 'Version is required'),
+  type: z.enum<MCPServerType, ['stdio', 'sse', 'streamable-http']>(['stdio', 'sse', 'streamable-http']),
+  url: z.string().url('Invalid URL format').nullable().optional(),
+  enabled: z.boolean().optional(),
+  envVars: z.record(z.string()).optional(),
+});
 
 export async function GET() {
   try {
-    const files = await fs.readdir(mcpSourceDir);
-    const serverFiles = files.filter((file) => file.endsWith('.ts') && !file.endsWith('.d.ts'));
-
-    const servers = await Promise.all(
-      serverFiles.map(async (file) => {
-        const filePath = path.join(mcpSourceDir, file);
-        const content = await fs.readFile(filePath, 'utf-8');
-
-        // Extract server name and version from the file content
-        const nameMatch = content.match(/name:\s*['"]([^'"]+)['"]/);
-        const versionMatch = content.match(/version:\s*['"]([^'"]+)['"]/);
-
-        return {
-          name: path.basename(file, '.ts'),
-          serverName: nameMatch ? nameMatch[1] : path.basename(file, '.ts'),
-          version: versionMatch ? versionMatch[1] : '1.0.0',
-          filePath: file,
-          enabled: false
-        };
-      })
-    );
-
+    // Fetch servers from the database
+    const servers = await getUserMcpServers(dbAccess);
     return NextResponse.json(servers);
   } catch (error) {
-    console.error('Error reading MCP servers:', error);
-    return NextResponse.json({ error: 'Failed to read MCP servers' }, { status: 500 });
+    console.error('Error fetching MCP servers from database:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+    return NextResponse.json({ error: 'Failed to fetch MCP servers from database', details: errorMessage }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const validatedData = mcpServerInsertSchema.safeParse(body);
+
+    if (!validatedData.success) {
+      return NextResponse.json({ error: 'Invalid input', details: validatedData.error.flatten() }, { status: 400 });
+    }
+
+    // Logic for type and url:
+    // If type is 'stdio', url should ideally be null.
+    if (validatedData.data.type === 'stdio' && validatedData.data.url) {
+        // Optionally, force URL to null for stdio, or return a specific error
+        // For now, let's allow it but it might be refined based on strictness requirements
+        // validatedData.data.url = null; 
+    } else if ((validatedData.data.type === 'sse' || validatedData.data.type === 'streamable-http') && !validatedData.data.url) {
+      return NextResponse.json({ error: `URL is required for type '${validatedData.data.type}'` }, { status: 400 });
+    }
+    
+    const newServer = await addUserMcpServerToDB(dbAccess, validatedData.data);
+    return NextResponse.json(newServer, { status: 201 });
+
+  } catch (error) {
+    console.error('Error creating MCP server:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+    // Check for specific error messages from addUserMcpServerToDB (e.g., unique constraints)
+    if (errorMessage.includes('already exists')) {
+        return NextResponse.json({ error: errorMessage }, { status: 409 }); // Conflict
+    }
+    return NextResponse.json({ error: 'Failed to create MCP server', details: errorMessage }, { status: 500 });
   }
 }

--- a/apps/dbagent/src/components/mcp/action.ts
+++ b/apps/dbagent/src/components/mcp/action.ts
@@ -8,7 +8,7 @@ import { addUserMcpServerToDB, deleteUserMcpServer, getUserMcpServer, updateUser
 import { MCPServer, MCPServerInsert } from '~/lib/db/schema';
 
 //playbook db insert
-export async function actionAddUserMcpServerToDB(input: MCPServer): Promise<MCPServer> {
+export async function actionAddUserMcpServerToDB(input: MCPServerInsert): Promise<MCPServer> {
   const dbAccess = await getUserSessionDBAccess();
   return await addUserMcpServerToDB(dbAccess, input);
 }

--- a/apps/dbagent/src/components/mcp/mcp-table.tsx
+++ b/apps/dbagent/src/components/mcp/mcp-table.tsx
@@ -108,6 +108,18 @@ export function McpTable() {
       <TableCell>
         <div className="bg-muted h-4 w-24 animate-pulse rounded" />
       </TableCell>
+      <TableCell>
+        <div className="bg-muted h-4 w-16 animate-pulse rounded" />
+      </TableCell>
+      <TableCell>
+        <div className="bg-muted h-4 w-32 animate-pulse rounded" />
+      </TableCell>
+      <TableCell>
+        <div className="bg-muted h-4 w-12 animate-pulse rounded" />
+      </TableCell>
+      <TableCell>
+        <div className="bg-muted h-4 w-20 animate-pulse rounded" />
+      </TableCell>
     </TableRow>
   );
 
@@ -133,6 +145,8 @@ export function McpTable() {
           <TableRow>
             <TableHead>Sever Name</TableHead>
             <TableHead>File</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead>URL</TableHead>
             <TableHead>Enabled</TableHead>
             <TableHead>Actions</TableHead>
           </TableRow>
@@ -165,6 +179,31 @@ export function McpTable() {
                 </div>
               </TableCell>
               <TableCell>{server.filePath}</TableCell>
+              <TableCell>
+                <Badge variant={server.type === 'stdio' ? 'outline' : 'default'}>
+                  {server.type}
+                </Badge>
+              </TableCell>
+              <TableCell>
+                {server.url ? (
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <Link
+                        href={server.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="truncate hover:underline"
+                        style={{ maxWidth: '150px', display: 'inline-block' }}
+                      >
+                        {server.url}
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent>{server.url}</TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <span className="text-muted-foreground">N/A</span>
+                )}
+              </TableCell>
               <TableCell>
                 <Switch checked={server.enabled} onCheckedChange={() => handleToggleEnabled(server)} />
               </TableCell>

--- a/apps/dbagent/src/lib/db/mcp-servers.ts
+++ b/apps/dbagent/src/lib/db/mcp-servers.ts
@@ -23,41 +23,98 @@ export async function getUserMcpServer(dbAccess: DBAccess, serverName: string) {
 //might need to update this for version and filepath aswell
 export async function updateUserMcpServer(dbAccess: DBAccess, input: MCPServerInsert) {
   return await dbAccess.query(async ({ db }) => {
+    const updateData: Partial<MCPServerInsert> = {};
+    // Check and add fields to updateData if they are provided in input
+    if (input.enabled !== undefined) {
+      updateData.enabled = input.enabled;
+    }
+    if (input.envVars !== undefined) {
+      updateData.envVars = input.envVars;
+    }
+    if (input.type !== undefined) {
+      updateData.type = input.type;
+    }
+    // Explicitly check for undefined to allow setting url to null
+    if (input.url !== undefined) {
+      updateData.url = input.url;
+    }
+    if (input.version !== undefined) {
+      updateData.version = input.version;
+    }
+    if (input.filePath !== undefined) {
+      updateData.filePath = input.filePath;
+    }
+    // serverName can also be updated
+    if (input.serverName !== undefined) {
+      updateData.serverName = input.serverName;
+    }
+
+    // Ensure input.name is present, as it's used in the WHERE clause
+    if (!input.name) {
+      throw new Error('Server name (input.name) is required for update.');
+    }
+
+    // If no updatable fields were provided, fetch and return the existing server
+    if (Object.keys(updateData).length === 0) {
+      const currentServer = await db.select().from(mcpServers).where(eq(mcpServers.name, input.name)).limit(1);
+      if (currentServer.length === 0) {
+        throw new Error(`[UPDATE]Server with name "${input.name}" not found.`);
+      }
+      return currentServer[0];
+    }
+    
+    // Note: If input.serverName is being updated, and it's unique,
+    // this could fail if another record already has the new serverName.
+    // The DB unique constraint will handle this.
     const result = await db
       .update(mcpServers)
-      .set({
-        enabled: input.enabled,
-        envVars: input.envVars
-      })
-      .where(eq(mcpServers.name, input.name))
+      .set(updateData)
+      .where(eq(mcpServers.name, input.name)) 
       .returning();
 
     if (result.length === 0) {
-      throw new Error(`[UPDATE]Server with name "${input.name}" not found`);
+      // This might happen if the server name in input.name doesn't exist
+      // or if the unique constraint on serverName failed during an update of serverName.
+      throw new Error(`[UPDATE]Server with name "${input.name}" not found, or update failed due to constraints (e.g., serverName already exists).`);
     }
 
     return result[0];
   });
 }
 
-export async function addUserMcpServerToDB(dbAccess: DBAccess, input: MCPServer): Promise<MCPServer> {
+export async function addUserMcpServerToDB(dbAccess: DBAccess, input: MCPServerInsert): Promise<MCPServer> {
   return await dbAccess.query(async ({ db }) => {
-    // Check if server with same name exists
-    const existingServer = await db.select().from(mcpServers).where(eq(mcpServers.name, input.serverName)).limit(1);
+    // Validate required fields from MCPServerInsert
+    if (!input.name || !input.serverName || !input.filePath || !input.version) {
+      throw new Error('Required fields (name, serverName, filePath, version) are missing from input.');
+    }
 
-    if (existingServer.length > 0) {
-      throw new Error(`Server with name "${input.serverName}" already exists`);
+    // Check if server with same name or serverName exists
+    const existingServerByName = await db.select().from(mcpServers).where(eq(mcpServers.name, input.name)).limit(1);
+    if (existingServerByName.length > 0) {
+      throw new Error(`Server with name "${input.name}" already exists`);
+    }
+
+    // serverName is required by the check above, so no need for "if (input.serverName)"
+    const existingServerByServerName = await db.select().from(mcpServers).where(eq(mcpServers.serverName, input.serverName)).limit(1);
+    if (existingServerByServerName.length > 0) {
+      throw new Error(`Server with serverName "${input.serverName}" already exists`);
     }
 
     // Create new server
+    // All fields in MCPServerInsert should be passed.
+    // Drizzle handles undefined for optional fields (inserts NULL or uses default)
     const result = await db
       .insert(mcpServers)
       .values({
-        name: input.name,
-        serverName: input.serverName,
-        version: input.version,
-        filePath: input.filePath,
-        enabled: input.enabled
+        name: input.name, // required
+        serverName: input.serverName, // required
+        filePath: input.filePath, // required
+        version: input.version, // required
+        enabled: input.enabled, // has default
+        envVars: input.envVars, // has default
+        type: input.type, // has default
+        url: input.url // optional (nullable)
       })
       .returning();
 

--- a/apps/dbagent/src/lib/db/schema.ts
+++ b/apps/dbagent/src/lib/db/schema.ts
@@ -37,6 +37,9 @@ export type MemberRole = InferEnumType<typeof memberRole>;
 export const cloudProvider = pgEnum('cloud_provider', ['aws', 'gcp', 'other']);
 export type CloudProvider = InferEnumType<typeof cloudProvider>;
 
+export const mcpServerType = pgEnum('mcp_server_type', ['stdio', 'sse', 'streamable-http']);
+export type MCPServerType = InferEnumType<typeof mcpServerType>;
+
 export const awsClusters = pgTable(
   'aws_clusters',
   {
@@ -684,7 +687,9 @@ export const mcpServers = pgTable(
     version: text('version').notNull(),
     enabled: boolean('enabled').default(true).notNull(),
     envVars: jsonb('env_vars').$type<Record<string, string>>().default({}).notNull(),
-    createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull()
+    createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull(),
+    type: mcpServerType('type').default('stdio'),
+    url: text('url')
   },
   (table) => [
     unique('uq_mcp_servers_name').on(table.name),


### PR DESCRIPTION
This commit introduces support for different types of MCP (Managed Component Process) servers, allowing for remote server configurations in addition to the existing stdio-based ones.

Key changes:

1.  **Schema Updates:**
    *   Added a new PostgreSQL enum `mcp_server_type` with values: `stdio`, `sse` (Server-Sent Events), and `streamable-http`.
    *   The `mcp_servers` table now includes:
        *   A `type` column (of `mcp_server_type`, defaulting to `stdio`).
        *   A nullable `url` column (text) to store the endpoint for remote servers.
    *   A database migration (`0009_mcp_server_type_and_url.sql`) has been added.
    *   `MCPServer` and `MCPServerInsert` types in `schema.ts` are updated accordingly.

2.  **Backend Logic:**
    *   CRUD functions in `apps/dbagent/src/lib/db/mcp-servers.ts` (`addUserMcpServerToDB`, `updateUserMcpServer`) now handle the `type` and `url` fields.
    *   API routes under `apps/dbagent/src/app/api/mcp/servers/` have been updated:
        *   Request bodies and responses now include `type` and `url`.
        *   Zod validation schemas are in place for these new fields, including logic to require `url` for `sse` and `streamable-http` types.

3.  **UI Enhancements:**
    *   The MCP server management table (`mcp-table.tsx`) now displays the `type` and `url` of each server.
    *   The MCP server creation/editing form (`mcp-view.tsx`):
        *   Includes a dropdown to select the server `type`.
        *   Conditionally displays a `url` input field only when `type` is `sse` or `streamable-http`.
        *   Handles client-side logic to clear/nullify `url` when `type` is `stdio`.
        *   The `name` field is now editable only during server creation.
    *   Server actions in `action.ts` have been updated to support the new fields.

These changes enable you to configure and manage MCP servers that operate via stdio, SSE, or streamable HTTP, providing greater flexibility in deploying and integrating managed components.