### PR TITLE
fix(docker-compose): restart after hosts restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   postgres:
     image: postgres:17
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-dbagent}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
@@ -13,6 +14,7 @@ services:
 
   xata-agent:
     image: xataio/agent:0.3.1
+    restart: unless-stopped
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-dbagent}:${POSTGRES_PASSWORD:-changeme}@postgres:5432/${POSTGRES_DB:-dbagent}
       NODE_ENV: production


### PR DESCRIPTION
Currently, agent doesn't restart if the host machine is restarted. This fixes it. Chose `unless-stopped` over `always`.

| Policy | What happens after you run `docker stop <ctr>` | On next Docker/host reboot |
|--------|-----------------------------------------------|----------------------------|
| `always` | Container stays stopped **for now**, but Docker “forgets” that you stopped it and will start it again the next time the daemon (or the host) starts. | Will start automatically. |
| `unless-stopped` | Container stays stopped **and** Docker remembers that choice. | Will **not** start—because you had stopped it. |
