### PR TITLE
feat: make OPENAI_API_KEY optional

### DIFF
--- a/apps/dbagent/playground/default/index.ts
+++ b/apps/dbagent/playground/default/index.ts
@@ -5,13 +5,13 @@ import { CloudProvider } from '~/lib/db/schema';
 
 import { openai } from '@ai-sdk/openai';
 import { getChatSystemPrompt, getMonitoringSystemPrompt } from '~/lib/ai/agent';
-import { getBuiltinProviderRegistry } from '~/lib/ai/providers';
+import { getProviderRegistry } from '~/lib/ai/providers';
 import { buildPlaygroundTools } from '../tools';
 
 /* eslint-disable no-process-env */
-const defaultModel = getBuiltinProviderRegistry()
-  .languageModel(process.env.MASTRA_MODEL ?? 'chat')
-  .instance();
+const defaultModel = await getProviderRegistry().then((registry) =>
+  registry.languageModel(process.env.MASTRA_MODEL ?? 'chat').instance()
+);
 const cloudProvider = (process.env.MASTRA_CLOUD_PROVIDER ?? 'aws') as CloudProvider;
 const defaultTools = buildPlaygroundTools({
   projectConnection: process.env.MASTRA_PROJECT_CONNECTION ?? undefined,

--- a/apps/dbagent/src/lib/ai/providers/builtin.test.ts
+++ b/apps/dbagent/src/lib/ai/providers/builtin.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the env module before importing builtin
+const mockEnv = {
+  OPENAI_API_KEY: undefined as string | undefined,
+  OPENAI_BASE_URL: undefined as string | undefined,
+  DEEPSEEK_API_KEY: undefined as string | undefined,
+  ANTHROPIC_API_KEY: undefined as string | undefined,
+  GOOGLE_GENERATIVE_AI_API_KEY: undefined as string | undefined
+};
+
+vi.mock('~/lib/env/server', () => ({
+  env: mockEnv
+}));
+
+// Mock AI SDK providers to avoid actual API calls
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: vi.fn(() => ({
+    languageModel: vi.fn((id: string) => ({ modelId: id, provider: 'openai' }))
+  }))
+}));
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  anthropic: {
+    languageModel: vi.fn((id: string) => ({ modelId: id, provider: 'anthropic' }))
+  }
+}));
+
+vi.mock('@ai-sdk/deepseek', () => ({
+  deepseek: {
+    languageModel: vi.fn((id: string) => ({ modelId: id, provider: 'deepseek' }))
+  }
+}));
+
+vi.mock('@ai-sdk/google', () => ({
+  google: {
+    languageModel: vi.fn((id: string) => ({ modelId: id, provider: 'google' }))
+  }
+}));
+
+describe('Builtin Provider Registry', () => {
+  beforeEach(() => {
+    // Reset all env vars before each test
+    mockEnv.OPENAI_API_KEY = undefined;
+    mockEnv.OPENAI_BASE_URL = undefined;
+    mockEnv.DEEPSEEK_API_KEY = undefined;
+    mockEnv.ANTHROPIC_API_KEY = undefined;
+    mockEnv.GOOGLE_GENERATIVE_AI_API_KEY = undefined;
+
+    // Clear module cache to re-evaluate lazy initialization
+    vi.resetModules();
+  });
+
+  describe('getBuiltinProviderRegistry', () => {
+    it('should return null when no API keys are configured', async () => {
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+
+      expect(registry).toBeNull();
+    });
+
+    it('should return registry with OpenAI models when OPENAI_API_KEY is set', async () => {
+      mockEnv.OPENAI_API_KEY = 'test-openai-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+
+      expect(registry).not.toBeNull();
+      const models = registry!.listLanguageModels();
+      expect(models.length).toBeGreaterThan(0);
+
+      const modelIds = models.map((m) => m.info().id);
+      expect(modelIds).toContain('openai:gpt-5');
+      expect(modelIds).toContain('openai:gpt-4o');
+    });
+
+    it('should return registry with Anthropic models when ANTHROPIC_API_KEY is set', async () => {
+      mockEnv.ANTHROPIC_API_KEY = 'test-anthropic-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+
+      expect(registry).not.toBeNull();
+      const models = registry!.listLanguageModels();
+      expect(models.length).toBeGreaterThan(0);
+
+      const modelIds = models.map((m) => m.info().id);
+      expect(modelIds).toContain('anthropic:claude-sonnet-4-5');
+      expect(modelIds).toContain('anthropic:claude-opus-4-1');
+      // Should NOT contain OpenAI models
+      expect(modelIds).not.toContain('openai:gpt-5');
+    });
+
+    it('should return registry with DeepSeek models when DEEPSEEK_API_KEY is set', async () => {
+      mockEnv.DEEPSEEK_API_KEY = 'test-deepseek-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+
+      expect(registry).not.toBeNull();
+      const models = registry!.listLanguageModels();
+
+      const modelIds = models.map((m) => m.info().id);
+      expect(modelIds).toContain('deepseek:chat');
+    });
+
+    it('should return registry with Google models when GOOGLE_GENERATIVE_AI_API_KEY is set', async () => {
+      mockEnv.GOOGLE_GENERATIVE_AI_API_KEY = 'test-google-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+
+      expect(registry).not.toBeNull();
+      const models = registry!.listLanguageModels();
+
+      const modelIds = models.map((m) => m.info().id);
+      expect(modelIds).toContain('google:gemini-2.5-pro');
+      expect(modelIds).toContain('google:gemini-2.5-flash');
+    });
+
+    it('should return registry with models from multiple providers when multiple keys are set', async () => {
+      mockEnv.OPENAI_API_KEY = 'test-openai-key';
+      mockEnv.ANTHROPIC_API_KEY = 'test-anthropic-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+
+      expect(registry).not.toBeNull();
+      const models = registry!.listLanguageModels();
+
+      const modelIds = models.map((m) => m.info().id);
+      // Should contain both OpenAI and Anthropic models
+      expect(modelIds).toContain('openai:gpt-5');
+      expect(modelIds).toContain('anthropic:claude-sonnet-4-5');
+    });
+
+    it('should memoize the registry (return same instance on subsequent calls)', async () => {
+      mockEnv.OPENAI_API_KEY = 'test-openai-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry1 = getBuiltinProviderRegistry();
+      const registry2 = getBuiltinProviderRegistry();
+
+      expect(registry1).toBe(registry2);
+    });
+  });
+
+  describe('hasBuiltinProviders', () => {
+    it('should return false when no API keys are configured', async () => {
+      const { hasBuiltinProviders } = await import('./builtin');
+
+      expect(hasBuiltinProviders()).toBe(false);
+    });
+
+    it('should return true when at least one API key is configured', async () => {
+      mockEnv.DEEPSEEK_API_KEY = 'test-key';
+
+      const { hasBuiltinProviders } = await import('./builtin');
+
+      expect(hasBuiltinProviders()).toBe(true);
+    });
+  });
+
+  describe('Default Model Selection', () => {
+    it('should use OpenAI GPT-5 as default when OpenAI is configured', async () => {
+      mockEnv.OPENAI_API_KEY = 'test-openai-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+      const defaultModel = registry!.defaultLanguageModel();
+
+      expect(defaultModel).not.toBeNull();
+      expect(defaultModel!.info().id).toBe('openai:gpt-5');
+    });
+
+    it('should use first available model as default when OpenAI is not configured', async () => {
+      mockEnv.ANTHROPIC_API_KEY = 'test-anthropic-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+      const defaultModel = registry!.defaultLanguageModel();
+
+      expect(defaultModel).not.toBeNull();
+      // First Anthropic model should be the default
+      expect(defaultModel!.info().id).toBe('anthropic:claude-sonnet-4-5');
+    });
+  });
+
+  describe('Model Aliases', () => {
+    it('should resolve chat alias to default model', async () => {
+      mockEnv.OPENAI_API_KEY = 'test-openai-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+      const chatModel = registry!.languageModel('chat');
+
+      expect(chatModel.info().id).toBe('openai:gpt-5');
+    });
+
+    it('should resolve title alias to GPT-5-mini when OpenAI is configured', async () => {
+      mockEnv.OPENAI_API_KEY = 'test-openai-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+      const titleModel = registry!.languageModel('title');
+
+      expect(titleModel.info().id).toBe('openai:gpt-5-mini');
+    });
+
+    it('should resolve aliases to first available model when OpenAI is not configured', async () => {
+      mockEnv.DEEPSEEK_API_KEY = 'test-deepseek-key';
+
+      const { getBuiltinProviderRegistry } = await import('./builtin');
+
+      const registry = getBuiltinProviderRegistry();
+      const chatModel = registry!.languageModel('chat');
+
+      // Should fallback to first DeepSeek model
+      expect(chatModel.info().id).toBe('deepseek:chat');
+    });
+  });
+});

--- a/apps/dbagent/src/lib/ai/providers/builtin.ts
+++ b/apps/dbagent/src/lib/ai/providers/builtin.ts
@@ -184,6 +184,14 @@ export function getBuiltinProviderRegistry(): ProviderRegistry | null {
   return _builtinProviderRegistry;
 }
 
+/**
+ * Check if any builtin provider API keys are configured.
+ * This is a lightweight check that doesn't initialize the registry.
+ */
+export function hasBuiltinApiKeys(): boolean {
+  return !!(env.OPENAI_API_KEY || env.ANTHROPIC_API_KEY || env.DEEPSEEK_API_KEY || env.GOOGLE_GENERATIVE_AI_API_KEY);
+}
+
 export function hasBuiltinProviders(): boolean {
   return getBuiltinProviderRegistry() !== null;
 }

--- a/apps/dbagent/src/lib/ai/providers/index.ts
+++ b/apps/dbagent/src/lib/ai/providers/index.ts
@@ -13,12 +13,12 @@ import { cached, combineRegistries, memoize } from './utils';
 const CACHE_TTL_MS = 60 * 1000; // 1 minute
 
 function buildProviderRegistry() {
-  const registries: (() => Promise<ProviderRegistry>)[] = [];
+  const registries: (() => Promise<ProviderRegistry | null>)[] = [];
 
   // Will be true if we have a provider that requires to fetch updates from a remote source.
   let requiresUpdates = false;
 
-  // Choose base registry. Builtin or LiteLLM is always available.
+  // Choose base registry: LiteLLM takes precedence, otherwise use builtin providers if available
   if (env.LITELLM_BASE_URL && env.LITELLM_API_KEY) {
     requiresUpdates = true;
     registries.push(
@@ -29,6 +29,8 @@ function buildProviderRegistry() {
         })
     );
   } else {
+    // Only add builtin registry if at least one builtin provider is configured
+    // This allows the app to start with only Ollama (no API keys required)
     registries.push(() => Promise.resolve(getBuiltinProviderRegistry()));
   }
 
@@ -44,17 +46,26 @@ function buildProviderRegistry() {
     );
   }
 
-  if (registries.length === 0) {
-    throw new Error('No provider registry configured');
+  // Check if we have any potential providers configured
+  // Note: builtin registry may return null if no API keys are set, but that's OK if Ollama is configured
+  const hasLiteLLM = env.LITELLM_BASE_URL && env.LITELLM_API_KEY;
+  const hasOllama = !!env.OLLAMA_HOST;
+  const hasBuiltinKeys =
+    env.OPENAI_API_KEY || env.ANTHROPIC_API_KEY || env.DEEPSEEK_API_KEY || env.GOOGLE_GENERATIVE_AI_API_KEY;
+
+  if (!hasLiteLLM && !hasOllama && !hasBuiltinKeys) {
+    throw new Error(
+      'No LLM providers configured. Set at least one of: ' +
+        'OPENAI_API_KEY, ANTHROPIC_API_KEY, DEEPSEEK_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, ' +
+        'OLLAMA_HOST, or LITELLM_BASE_URL + LITELLM_API_KEY'
+    );
   }
 
-  const build =
-    registries.length === 1
-      ? registries[0]!
-      : async () => {
-          const buildRegistries = await Promise.all(registries.map((registry) => registry()));
-          return combineRegistries(buildRegistries);
-        };
+  // Always use combineRegistries to properly handle null values from builtin registry
+  const build = async (): Promise<ProviderRegistry> => {
+    const buildRegistries = await Promise.all(registries.map((registry) => registry()));
+    return combineRegistries(buildRegistries);
+  };
 
   return requiresUpdates ? cached(CACHE_TTL_MS, build) : memoize(build);
 }

--- a/apps/dbagent/src/lib/ai/providers/index.ts
+++ b/apps/dbagent/src/lib/ai/providers/index.ts
@@ -4,7 +4,7 @@ export * from './ollama';
 export * from './types';
 
 import { env } from '~/lib/env/server';
-import { getBuiltinProviderRegistry } from './builtin';
+import { getBuiltinProviderRegistry, hasBuiltinApiKeys } from './builtin';
 import { createLiteLLMProviderRegistry } from './litellm';
 import { createOllamaProviderRegistry } from './ollama';
 import { Model, ModelWithFallback, ProviderRegistry } from './types';
@@ -48,12 +48,10 @@ function buildProviderRegistry() {
 
   // Check if we have any potential providers configured
   // Note: builtin registry may return null if no API keys are set, but that's OK if Ollama is configured
-  const hasLiteLLM = env.LITELLM_BASE_URL && env.LITELLM_API_KEY;
+  const hasLiteLLM = !!(env.LITELLM_BASE_URL && env.LITELLM_API_KEY);
   const hasOllama = !!env.OLLAMA_HOST;
-  const hasBuiltinKeys =
-    env.OPENAI_API_KEY || env.ANTHROPIC_API_KEY || env.DEEPSEEK_API_KEY || env.GOOGLE_GENERATIVE_AI_API_KEY;
 
-  if (!hasLiteLLM && !hasOllama && !hasBuiltinKeys) {
+  if (!hasLiteLLM && !hasOllama && !hasBuiltinApiKeys()) {
     throw new Error(
       'No LLM providers configured. Set at least one of: ' +
         'OPENAI_API_KEY, ANTHROPIC_API_KEY, DEEPSEEK_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, ' +


### PR DESCRIPTION
**Summary**

- Allow the application to start with only Ollama configured (no OpenAI/Anthropic/etc. API keys required)
- Refactor provider validation to use hasBuiltinApiKeys() function, eliminating duplicate checks
- Add comprehensive tests for builtin provider registry

**Problem**

Previously the backend would crash on startup with "No providers enabled. Please configure API keys" error even when using only Ollama models. Users had to set OPENAI_API_KEY=dummy-key-not-used as a workaround.

**Changes**

- Modified builtin.ts to return null when no API keys are configured instead of throwing
- Added hasBuiltinApiKeys() helper to centralize API key presence checking
- Updated index.ts to handle nullable builtin registry and provide clear error messages
- Added unit tests for provider registry initialization scenarios