### PR TITLE
fix: remove references to deleted packages/ and configs/ directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,6 @@ COPY package.json ./
 # This ensures all workspace packages are correctly identified
 COPY apps/dbagent/package.json ./apps/dbagent/
 
-# Now copy the source code of all workspace packages
-COPY packages/ ./packages/
-COPY configs/ ./configs/
-
 # Create a temporary directory for the archive
 RUN mkdir -p /tmp/dbagent
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,2 @@
 packages:
   - 'apps/*'
-  - 'configs/*'
-  - 'packages/*'


### PR DESCRIPTION
## Summary

- Remove obsolete COPY commands for `packages/` and `configs/` directories from Dockerfile
- Remove obsolete workspace entries from `pnpm-workspace.yaml`

These directories were removed in #135 when the project switched to official `@xata.io/*` npm packages, but the Dockerfile and pnpm-workspace.yaml still referenced them, causing Docker build failures:

```
ERROR: failed to solve: failed to compute cache key: "/configs": not found
```